### PR TITLE
feat(detect-js-redirect): return 307 when evaluated page url is different from initial url

### DIFF
--- a/src/api/routes/render.ts
+++ b/src/api/routes/render.ts
@@ -96,9 +96,13 @@ export async function renderJSON(
 ) {
   const { url } = res.locals;
   try {
-    const { error, statusCode, headers, body, timeout } = await renderer.task({ url });
+    const { error, statusCode, headers, body, timeout, resolvedUrl } = await renderer.task({ url });
     if (error) {
       res.status(400).json({ error });
+      return;
+    }
+    if (resolvedUrl !== url.href) {
+      res.status(307).header('Location', resolvedUrl).send();
       return;
     }
     res.status(200).json({

--- a/src/lib/Renderer.ts
+++ b/src/lib/Renderer.ts
@@ -335,6 +335,7 @@ class Renderer {
     await page.evaluate(injectBaseHref, baseHref);
 
     /* Serialize */
+    await page.evaluate( () => { debugger; } );
     let preSerializationUrl = page.url();
     const body = await page.evaluate("document.firstElementChild.outerHTML");
     const headers = response.headers();

--- a/src/lib/Renderer.ts
+++ b/src/lib/Renderer.ts
@@ -335,13 +335,19 @@ class Renderer {
     await page.evaluate(injectBaseHref, baseHref);
 
     /* Serialize */
+    let preSerializationUrl = page.url();
     const body = await page.evaluate("document.firstElementChild.outerHTML");
     const headers = response.headers();
-
+    const resolvedUrl = page.url();
     /* Cleanup */
     await context.close();
 
-    return { statusCode, headers, body, timeout };
+    if (preSerializationUrl !== resolvedUrl) {
+      // something super shady happened where the page url changed during evaluation
+      return { error: 'unsafe_redirect' };
+    }
+
+    return { statusCode, headers, body, timeout, resolvedUrl };
   }
 
   private _addTask({ id, promise }: taskObject) {


### PR DESCRIPTION
This PR gives renderscript the ability to detect when the evaluated page url was different from the url that is was provided and returns a 307 redirect with the location of the evaluated page.

Current known limitations:
- there is no way to make renderscript ignore certain queryParams, so if a uniqueID is generated in the search params, the page will redirect for ever 