### PR TITLE
feat(dns-filter): reject requests to private IPs

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "typescript-transform-paths": "1.1.11"
   },
   "dependencies": {
+    "@algolia/dns-filter": "^0.0.3",
     "ad-block": "4.1.7",
     "body-parser": "1.19.0",
     "express": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "typescript-transform-paths": "1.1.11"
   },
   "dependencies": {
-    "@algolia/dns-filter": "^0.0.3",
+    "@algolia/dns-filter": "^1.1.3",
     "ad-block": "4.1.7",
     "body-parser": "1.19.0",
     "express": "4.17.1",

--- a/src/lib/Renderer.ts
+++ b/src/lib/Renderer.ts
@@ -2,6 +2,11 @@ import * as path from "path";
 
 import * as puppeteer from "puppeteer-core";
 import * as uuid from "uuid/v4";
+import { validateURL, NetworkError, PRIVATE_IP_PREFIXES } from '@algolia/dns-filter';
+
+const RESTRICTED_IPS = process.env.NODE_ENV === 'development'
+  ? PRIVATE_IP_PREFIXES.filter((prefix: string) => !['127.', '0.', '::1'].includes(prefix)) // allow everything in dev
+  : PRIVATE_IP_PREFIXES; // no private IPs otherwise
 
 import injectBaseHref from "lib/helpers/injectBaseHref";
 import getChromiumExecutablePath from "lib/helpers/getChromiumExecutablePath";
@@ -271,6 +276,19 @@ class Renderer {
     /* Ignore useless resources */
     await page.setRequestInterception(true);
     page.on("request", async req => {
+      // check for ssrf attempts
+      try {
+        await validateURL({
+          url: req.url(),
+          ipPrefixes: RESTRICTED_IPS,
+        });
+      }
+      catch (err) {
+        // log.error(err);
+        // report(err);
+        req.abort();
+      }
+
       try {
         // Ignore some type of resources
         if (IGNORED_RESOURCES.includes(req.resourceType())) {

--- a/src/lib/Renderer.ts
+++ b/src/lib/Renderer.ts
@@ -2,7 +2,7 @@ import * as path from "path";
 
 import * as puppeteer from "puppeteer-core";
 import * as uuid from "uuid/v4";
-import { validateURL, NetworkError, PRIVATE_IP_PREFIXES } from '@algolia/dns-filter';
+import { validateURL, PRIVATE_IP_PREFIXES } from '@algolia/dns-filter';
 
 const RESTRICTED_IPS = process.env.NODE_ENV === 'development'
   ? PRIVATE_IP_PREFIXES.filter((prefix: string) => !['127.', '0.', '::1'].includes(prefix)) // allow everything in dev

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,12 @@
 # yarn lockfile v1
 
 
-"@algolia/dns-filter@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@algolia/dns-filter/-/dns-filter-0.0.3.tgz#c86620723f2891f02eb4076d8092a2f4adba3d52"
-  integrity sha512-TwZQJWIcH2OxId9Fmb8nHGzxjGUr+bnzP4tZLSc3R2PwUIC0TBSqDJ1P4wKjQclWtIWlHv4DmVTCcbW6cXwqLw==
+"@algolia/dns-filter@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@algolia/dns-filter/-/dns-filter-1.1.3.tgz#04e35ab98cbc136a62472ba8394a0230716adc68"
+  integrity sha512-wdcoWZoHNG/r59vQueEmIdNq1sxh5+AIWfMinUIER3i0yW6X2kzXA6XzKYRscUT7jV3RPCC5aKl71x+B1Tqulg==
+  dependencies:
+    ip-address "^6.1.0"
 
 "@babel/code-frame@^7.0.0":
   version "7.0.0"
@@ -2439,6 +2441,15 @@ invert-kv@^2.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
 
+ip-address@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-6.1.0.tgz#3c3335bc90f22b3545a6eca5bffefabeb2ea6fd2"
+  integrity sha512-u9YYtb1p2fWSbzpKmZ/b3QXWA+diRYPxc2c4y5lFB/MMk5WZ7wNZv8S3CFcIGVJ5XtlaCAl/FQy/D3eQ2XtdOA==
+  dependencies:
+    jsbn "1.1.0"
+    lodash "^4.17.15"
+    sprintf-js "1.1.2"
+
 ip-regex@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
@@ -2737,6 +2748,11 @@ js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+jsbn@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-1.1.0.tgz#b01307cb29b618a1ed26ec79e911f803c4da0040"
+  integrity sha1-sBMHyym2GKHtJux56RH4A8TaAEA=
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -5115,6 +5131,11 @@ split@^1.0.0:
   integrity sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==
   dependencies:
     through "2"
+
+sprintf-js@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.2.tgz#da1765262bf8c0f571749f2ad6c26300207ae673"
+  integrity sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==
 
 sprintf-js@~1.0.2:
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@algolia/dns-filter@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@algolia/dns-filter/-/dns-filter-0.0.3.tgz#c86620723f2891f02eb4076d8092a2f4adba3d52"
+  integrity sha512-TwZQJWIcH2OxId9Fmb8nHGzxjGUr+bnzP4tZLSc3R2PwUIC0TBSqDJ1P4wKjQclWtIWlHv4DmVTCcbW6cXwqLw==
+
 "@babel/code-frame@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"


### PR DESCRIPTION
This PR adds the capability for renderscript to reject requests that resolve to private IPs.

Currently blocked because library does not exist yet 😄