### PR TITLE
fix(allow-ip-prefixes): add environment variable to control which ips to whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ See `.env.prod` to see which ones are installed by default (they still need to b
   Example: `https://github.com/gorhill/uBlock/releases/download/1.19.6/uBlock0_1.19.6.chromium.zip`
 - `ALLOW_LOCALHOST`: Allow calls on localhost IPs
   Example: `ALLOW_LOCALHOST=true`
+- `IP_PREFIXES_WHITELIST`: a comma-separated list of prefixes to whitelist when `ALLOW_LOCALHOST` is set to true.
+  Example: `IP_PREFIXES_WHITELIST=127.,0.,::1` (these are the default values used when the variable is not provided alongside `ALLOW_LOCALHOST`)
 
 ## Credits
 

--- a/src/lib/Renderer.ts
+++ b/src/lib/Renderer.ts
@@ -4,8 +4,12 @@ import * as puppeteer from "puppeteer-core";
 import * as uuid from "uuid/v4";
 import { validateURL, PRIVATE_IP_PREFIXES } from '@algolia/dns-filter';
 
+const IP_PREFIXES_WHITELIST = process.env.IP_PREFIXES_WHITELIST 
+  ? process.env.IP_PREFIXES_WHITELIST.split(',') 
+  : ['127.', '0.', '::1'];
+
 const RESTRICTED_IPS = process.env.ALLOW_LOCALHOST === 'true'
-  ? PRIVATE_IP_PREFIXES.filter((prefix: string) => !['127.', '0.', '::1'].includes(prefix)) // relax filtering
+  ? PRIVATE_IP_PREFIXES.filter((prefix: string) => !IP_PREFIXES_WHITELIST.includes(prefix)) // relax filtering
   : PRIVATE_IP_PREFIXES; // no private IPs otherwise
 
 import injectBaseHref from "lib/helpers/injectBaseHref";


### PR DESCRIPTION
Closes #11 

This PR adds a new environment variable to give more control on which IPs to allow when running the service with `ALLOW_LOCALHOST=true`.