### PR TITLE
feat(forward-headers): handle forwarding of generic headers and cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ See `.env.prod` to see which ones are installed by default (they still need to b
   Example: `ALLOW_LOCALHOST=true`
 - `IP_PREFIXES_WHITELIST`: Comma-separated list of prefixes to whitelist when `ALLOW_LOCALHOST` is set to true.
   Example: `IP_PREFIXES_WHITELIST=127.,0.,::1` (these are the default values used when the variable is not provided alongside `ALLOW_LOCALHOST`)
-- `HEADERS_TO_FORWARD`: Comma-separated list of headers to forward on request
+- `HEADERS_TO_FORWARD`: Comma-separated list of headers to forward on navigation request
   Example: `HEADERS_TO_FORWARD=Cookie,Authorization` (default value)
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -59,14 +59,16 @@ open http://localhost:3000/render?url=https%3A%2F%2Fwww.algolia.com
 
 See `.env.prod` to see which ones are installed by default (they still need to be provided to `docker run` to be enabled).
 
-- `ADBLOCK_LISTS`: Comma separated list of adblocking lists download link  
+- `ADBLOCK_LISTS`: Comma-separated list of adblocking lists download link
   Example: `https://easylist.to/easylist/easylist.txt`
-- `EXTENSIONS`: Comma separated list of extensions download link (expects a `.zip` file)  
+- `EXTENSIONS`: Comma-separated list of extensions download link (expects a `.zip` file)
   Example: `https://github.com/gorhill/uBlock/releases/download/1.19.6/uBlock0_1.19.6.chromium.zip`
 - `ALLOW_LOCALHOST`: Allow calls on localhost IPs
   Example: `ALLOW_LOCALHOST=true`
-- `IP_PREFIXES_WHITELIST`: a comma-separated list of prefixes to whitelist when `ALLOW_LOCALHOST` is set to true.
+- `IP_PREFIXES_WHITELIST`: Comma-separated list of prefixes to whitelist when `ALLOW_LOCALHOST` is set to true.
   Example: `IP_PREFIXES_WHITELIST=127.,0.,::1` (these are the default values used when the variable is not provided alongside `ALLOW_LOCALHOST`)
+- `HEADERS_TO_FORWARD`: Comma-separated list of headers to forward on request
+  Example: `HEADERS_TO_FORWARD=Cookie,Authorization` (default value)
 
 ## Credits
 

--- a/src/api/routes/render.ts
+++ b/src/api/routes/render.ts
@@ -114,7 +114,6 @@ export async function renderJSON(
 ) {
   const { url } = res.locals;
   const headersToForward = getForwardedHeadersFromRequest(req);
-  console.log('headersToForward', headersToForward);
   try {
     const { error, statusCode, headers, body, timeout, resolvedUrl } = await renderer.task({ url, headersToForward });
     if (error) {

--- a/src/lib/Renderer.ts
+++ b/src/lib/Renderer.ts
@@ -26,6 +26,9 @@ const TIMEOUT = 10000;
 
 export interface taskParams {
   url: URL;
+  headersToForward: {
+    [s: string]: string;
+  }
 }
 
 export interface taskResult {
@@ -264,22 +267,25 @@ class Renderer {
     await extensionsPage.close();
   }
 
-  private async _createNewPage() {
-    if (this._stopping) {
-      throw new Error("Called _createNewPage on a stopping Renderer");
+  private async _defineRequestContextForPage(page: puppeteer.Page, { url, headersToForward }: taskParams) {
+    await page.setRequestInterception(true);
+    if (headersToForward.cookie) {
+      const cookies = headersToForward.cookie.split('; ').map(c => {
+        const [ key, ...v ] = c.split('=');
+        // url attribute is required because it is not possible set cookies on a blank page
+        // so page.setCookie would crash if no url is provided, since we start with a blank page
+        return { url: url.href, name: key, value: v.join('=') };
+      });
+      try {
+        await page.setCookie(...cookies)
+      }
+      catch (e) {
+        console.error('failed to set cookie on page', url);
+      }
     }
 
-    const browser = await this._getBrowser();
-    const context = await browser.createIncognitoBrowserContext();
-    const page = await context.newPage();
-
-    await page.setUserAgent("Algolia Crawler Renderscript");
-    await page.setCacheEnabled(false);
-    await page.setViewport({ width: WIDTH, height: HEIGHT });
-
-    /* Ignore useless resources */
-    await page.setRequestInterception(true);
-    page.on("request", async req => {
+    /* Ignore useless/dangerous resources */
+    page.on('request', async (req: puppeteer.Request) => {
       // check for ssrf attempts
       try {
         await validateURL({
@@ -311,12 +317,30 @@ class Renderer {
           return;
         }
         // console.log(req.resourceType(), req.url());
-        await req.continue();
+        const headers = req.headers();
+        await req.continue({
+          // headers ignore values set for `Cookie`, relies to page.setCookie instead
+          headers: { ...headers, ...headersToForward }
+        });
       } catch (e) {
         if (!e.message.match(/Request is already handled/)) throw e;
         // Ignore Request is already handled error
       }
     });
+  }
+
+  private async _createNewPage() {
+    if (this._stopping) {
+      throw new Error("Called _createNewPage on a stopping Renderer");
+    }
+
+    const browser = await this._getBrowser();
+    const context = await browser.createIncognitoBrowserContext();
+    const page = await context.newPage();
+
+    await page.setUserAgent("Algolia Crawler Renderscript");
+    await page.setCacheEnabled(false);
+    await page.setViewport({ width: WIDTH, height: HEIGHT });
 
     return { page, context };
   }
@@ -326,9 +350,11 @@ class Renderer {
     return await this._pageBuffer.shift()!;
   }
 
-  private async _processPage({ url }: taskParams, taskId: string) {
+  private async _processPage({ url, headersToForward }: taskParams, taskId: string) {
     /* Setup */
     const { context, page } = await this._newPage();
+
+    await this._defineRequestContextForPage(page, { url, headersToForward });
 
     let response: puppeteer.Response | null = null;
     let timeout = false;


### PR DESCRIPTION
This PR introduces the ability to forward headers to the page navigation requests.

It adds an environment variable called `HEADERS_TO_FORWARD` which accepts a comma separated list of headers to forward.

There is also special handling of cookies, since browser do not consider `Cookie` as a regular request header.

### How to test this PR
go on `https://crawler.algolia.com`, login, and get the Cookie header, then run `yarn dev` and
```sh
✗ curl -i -X POST 'http://localhost:3000/render' \
  -d 'url=https%3A%2F%2Fcrawler.algolia.com%2Fadmin%2Fuser_configs%2F${CONFIG_ID}%2Fteam' \
  -H 'Cookie: ${Cookie}'
```