### PR TITLE
fix(consistent-localhost): revert url translation when checking for redirection

### DIFF
--- a/src/api/helpers/buildUrl.ts
+++ b/src/api/helpers/buildUrl.ts
@@ -1,7 +1,7 @@
 const DOCKER_LOCALHOST = 'host.docker.internal';
 
 export function replaceHost(url: URL, from: string, to: string) {
-  const fromRegex = new RegExp(`/^${from}(:|$)/`)
+  const fromRegex = new RegExp(`^${from}(:|$)`)
   const host = url.host || '';
   url.host = host.replace(fromRegex, `${to}$1`);
   return url;

--- a/src/api/helpers/buildUrl.ts
+++ b/src/api/helpers/buildUrl.ts
@@ -1,7 +1,20 @@
-export default function buildUrl(href: string) {
+const DOCKER_LOCALHOST = 'host.docker.internal';
+
+export function replaceHost(url: URL, from: string, to: string) {
+  const fromRegex = new RegExp(`/^${from}(:|$)/`)
+  const host = url.host || '';
+  url.host = host.replace(fromRegex, `${to}$1`);
+  return url;
+}
+
+export function revertUrl(href: string) {
   const url = new URL(href);
   if (process.env.USE_DOCKER_LOCALHOST !== 'true') return url;
-  const host = url.host || '';
-  url.host = host.replace(/^localhost(:|$)/, 'host.docker.internal$1');
-  return url;
+  return replaceHost(url, DOCKER_LOCALHOST, 'localhost');
+}
+
+export function buildUrl(href: string) {
+  const url = new URL(href);
+  if (process.env.USE_DOCKER_LOCALHOST !== 'true') return url;
+  return replaceHost(url, 'localhost', DOCKER_LOCALHOST);
 }

--- a/src/api/routes/render.ts
+++ b/src/api/routes/render.ts
@@ -106,7 +106,7 @@ export async function renderJSON(
       res.status(400).json({ error });
       return;
     }
-    if (resolvedUrl && revertUrl(resolvedUrl)  !== url.href) {
+    if (resolvedUrl && revertUrl(resolvedUrl).href !== url.href) {
       const location = revertUrl(resolvedUrl).href;
       res.status(307).header('Location', location).send();
       return;


### PR DESCRIPTION
This PR fixes an issue when running with docker where localhost URLs would be detected as redirects because of the translation of `localhost` into `host.docker.internal`.

We now revert this translation before checking if the resolved url of the rendered page was the same as the initial url, and return a location with `localhost` instead of `host.docker.internal` if there was a redirection.