### PR TITLE
fix(docker-revert-url): revert only after comparison

### DIFF
--- a/src/api/routes/render.ts
+++ b/src/api/routes/render.ts
@@ -85,7 +85,7 @@ export async function render(
       res.status(400).json({ error });
       return;
     }
-    if (resolvedUrl && revertUrl(resolvedUrl)  !== url.href) {
+    if (resolvedUrl && resolvedUrl !== url.href) {
       const location = revertUrl(resolvedUrl).href;
       res.status(307).header('Location', location).send();
       return;
@@ -125,7 +125,7 @@ export async function renderJSON(
       res.status(400).json({ error });
       return;
     }
-    if (resolvedUrl && revertUrl(resolvedUrl).href !== url.href) {
+    if (resolvedUrl && resolvedUrl !== url.href) {
       const location = revertUrl(resolvedUrl).href;
       res.status(307).header('Location', location).send();
       return;


### PR DESCRIPTION
In the case where `USE_DOCKER_LOCALHOST=true`, `url.href` contains the `host.docker.internal`, and so does the resolved url, so we should compare it with the resolved value before transforming the resolved value with `localhost`, instead of after.

I don't know how I managed to have it working locally before. I guess I tested against a stale iteration.

closes #12 