### PR TITLE
fix(url-hash-redirect): use window.location.href instead of page.url

### DIFF
--- a/src/lib/Renderer.ts
+++ b/src/lib/Renderer.ts
@@ -397,10 +397,10 @@ class Renderer {
 
     /* Serialize */
     await page.evaluate( () => { debugger; } );
-    let preSerializationUrl = page.url();
+    const preSerializationUrl = await page.evaluate('window.location.href');
     const body = await page.evaluate("document.firstElementChild.outerHTML");
     const headers = response.headers();
-    const resolvedUrl = page.url();
+    const resolvedUrl = await page.evaluate('window.location.href');
     /* Cleanup */
     await context.close();
 


### PR DESCRIPTION
closes #18 

This PR fixes a bug where the hash of a page would be ignored during the check for redirection for one half of the comparison only, which created infinite loops in certain cases.

### how to test
```
yarn dev
```
The following query
```
curl -i -X POST 'http://localhost:3000/render' -d 'url=https%3A%2F%2Fwww.algolia.com%2Fdoc%2Fguides%2Fsecurity%2Fapi-keys%2F%23quick-overview'
```
should return a 200 instead of a 307.