### PR TITLE
fix(stale-yarn-lock): upgrade package that is an undeclared dep o…

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -235,9 +235,9 @@
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
 "@types/express-serve-static-core@*":
-  version "4.16.4"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.16.4.tgz#56bb8be4559401d68af4a3624ae9dd3166103e60"
-  integrity sha512-x/8h6FHm14rPWnW2HP5likD/rsqJ3t/77OWx2PLxym0hXbeBWQmcPyHmwX+CtCQpjIfgrUdEoDFcLPwPZWiqzQ==
+  version "4.16.11"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.16.11.tgz#46e8cb091de19d51731a05c2581e515855979dad"
+  integrity sha512-K8d2M5t3tBQimkyaYTXxtHYyoJPUEhy2/omVRnTAKw5FEdT+Ft6lTaTOpoJdHeG+mIwQXXtqiTcYZ6IR8LTzjQ==
   dependencies:
     "@types/node" "*"
     "@types/range-parser" "*"


### PR DESCRIPTION
Renovate upgraded `@types/express` from 4.17.1 to 4.17.2, and this patch broke our build, because it has an undeclared strong dependency to `@types/express-serve-static-core@4.16.11` (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/38887).

This PR updates our yarn.lock to reflect that undocumented dependency.

### How to test
this will fail on master and succeed on this branch:
```
rm -rf node_modules
yarn
yarn build
```