### PR TITLE
fix: move 2-steps logging logs to the right place

### DIFF
--- a/src/lib/Renderer.ts
+++ b/src/lib/Renderer.ts
@@ -386,6 +386,8 @@ class Renderer {
           }),
           textInput!.press('Enter'),
         ]);
+        console.log(`2 step login: navigated to ${page.url()}`);
+        passwordInput = await page.$('input[type=password]');
       } catch (err) {
         console.log('Found no password input on the page');
         const body = await this._renderBody(page, new URL(page.url()));
@@ -393,8 +395,6 @@ class Renderer {
       }
     }
 
-    console.log(`2 step login: navigated to ${page.url()}`);
-    passwordInput = await page.$('input[type=password]');
     console.log('Logging in...');
     await passwordInput!.type(task.login!.password);
     let loginResponse;

--- a/src/lib/helpers/injectBaseHref.ts
+++ b/src/lib/helpers/injectBaseHref.ts
@@ -1,7 +1,7 @@
 /**
  * Injects a <base> tag which allows other resources to load on the
  * page without trying to get them from the `renderscript` server.
- * Ithas no effect on serialised output, but allows it to verify render
+ * It has no effect on serialised output, but allows it to verify render
  * quality.
  */
 export default function injectBaseHref(origin: string): void {


### PR DESCRIPTION
The "2 step logging" log was also displayed for a single page login