### PR TITLE
feat: expose more metrics

### DIFF
--- a/public/static/main.webmanifest
+++ b/public/static/main.webmanifest
@@ -1,0 +1,14 @@
+{
+  "name": "",
+  "short_name": "",
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff",
+  "display": "standalone"
+}

--- a/public/test-website/blocked-requests.html
+++ b/public/test-website/blocked-requests.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <!-- CSS NOT BLOCKED but fonts inside yes -->
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@1,100&display=swap" rel="stylesheet">
+
+  <style>
+    /* This font should be different than the <link> one */
+    /* BLOCKED */
+    @font-face {
+      font-family: 'Qahiri';
+      font-style: normal;
+      font-weight: 400;
+      font-display: swap;
+      src: url(https://fonts.gstatic.com/s/qahiri/v1/tsssAp1RZy0C_hGeVHqgjHq-pg.woff2) format('woff2');
+      unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+    }
+
+    .font-qahiri {
+      font-family: 'Qahiri', sans-serif;
+    }
+
+    .font-roboto {
+      font-family: 'Roboto', sans-serif;
+    }
+
+    /** BLOCKED **/
+    .img-bg {
+      background-image: url('https://res.cloudinary.com/hilnmyskv/image/upload/v1623928136/ui-library/nav/search.svg');
+    }
+  </style>
+
+  <!-- NOT BLOCKED but not loaded too -->
+  <link rel="manifest" href="/test-website/static/main.webmanifest">
+</head>
+
+<body>
+  A basic page
+
+  <!-- BLOCKED -->
+  <img src="https://via.placeholder.com/150" />
+
+  <!-- BLOCKED -->
+  <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" alt="" />
+
+  <!-- BLOCKED -->
+  <img srcset="https://via.placeholder.com/151 480w, https://via.placeholder.com/152 800w" sizes="(max-width: 600px) 480px,
+            800px" src="elva-fairy-800w.jpg" alt="Hello">
+
+  <div class="font-roboto">Hello</div>
+  <div class="font-qahiri">Foo</div>
+  <div class="img-bg">Img Bg</div>
+
+</body>
+
+</html>

--- a/src/__tests__/blockedRequests.test.ts
+++ b/src/__tests__/blockedRequests.test.ts
@@ -1,0 +1,20 @@
+import { request } from './helpers';
+
+it('should block basic unecessary requests', async () => {
+  const { res, body } = await request('http://localhost:3000/render', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      url: 'http://localhost:3000/test-website/blocked-requests.html',
+      ua: 'Algolia Crawler',
+    }),
+  });
+
+  const json = JSON.parse(body);
+
+  expect(res.statusCode).toEqual(200);
+  expect(json.metrics.page.requests).toEqual(8);
+  expect(json.metrics.page.blockedRequests).toEqual(6);
+});

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -104,4 +104,50 @@ describe('main', () => {
 
     expect(cleanString(body)).toEqual('');
   });
+
+  it('should expose metrics', async () => {
+    const { res, body } = await request('http://localhost:3000/render', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        url: 'http://localhost:3000/test-website/async.html',
+        ua: 'Algolia Crawler',
+      }),
+    });
+
+    const json = JSON.parse(body);
+
+    expect(res.statusCode).toEqual(200);
+
+    expect(json.metrics).toMatchObject({
+      goto: expect.any(String),
+      minWait: expect.any(Number),
+      serialize: expect.any(Number),
+      total: expect.any(Number),
+      page: {
+        layoutDuration: expect.any(Number),
+        scriptDuration: expect.any(Number),
+        taskDuration: expect.any(Number),
+        jsHeapUsedSize: expect.any(Number),
+        jsHeapTotalSize: expect.any(Number),
+        requests: expect.any(Number),
+        blockedRequests: expect.any(Number),
+        contentLength: 763,
+        contentLengthTotal: 763,
+      },
+    });
+    expect(json.metrics.goto).toBeLessThanOrEqual(1100);
+    expect(json.metrics.minWait).toBeLessThanOrEqual(1100);
+    expect(json.metrics.serialize).toBeLessThanOrEqual(20);
+    expect(json.metrics.total).toBeLessThanOrEqual(2100);
+    expect(json.metrics.page.layoutDuration).toBeLessThanOrEqual(0.02);
+    expect(json.metrics.page.scriptDuration).toBeLessThanOrEqual(0.01);
+    expect(json.metrics.page.taskDuration).toBeLessThanOrEqual(0.1);
+    expect(json.metrics.page.jsHeapUsedSize).toBeLessThanOrEqual(1617360);
+    expect(json.metrics.page.jsHeapTotalSize).toBeLessThanOrEqual(2639520);
+    expect(json.metrics.page.requests).toEqual(1);
+    expect(json.metrics.page.blockedRequests).toEqual(0);
+  });
 });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -122,7 +122,7 @@ describe('main', () => {
     expect(res.statusCode).toEqual(200);
 
     expect(json.metrics).toMatchObject({
-      goto: expect.any(String),
+      goto: expect.any(Number),
       minWait: expect.any(Number),
       serialize: expect.any(Number),
       total: expect.any(Number),

--- a/src/lib/TasksManager.ts
+++ b/src/lib/TasksManager.ts
@@ -76,6 +76,7 @@ export class TasksManager {
     const res = task.results!;
 
     this.#removeTask({ id });
+    await task.close();
 
     stats.timing('renderscript.task', Date.now() - start, undefined, {
       type: job.type,

--- a/src/lib/browser/Browser.ts
+++ b/src/lib/browser/Browser.ts
@@ -56,9 +56,11 @@ export class Browser {
     const testPage = await browser.newPage();
     await testPage.goto('about://settings', { waitUntil: 'networkidle0' });
     stats.timing('renderscript.page.initial', Date.now() - start);
+    testPage.close();
 
     this.#browser = browser;
     this.#ready = true;
+    console.log(`Browser is ready`);
   }
 
   async stop(): Promise<void> {

--- a/src/lib/tasks/Task.ts
+++ b/src/lib/tasks/Task.ts
@@ -10,6 +10,7 @@ export abstract class Task<TTaskType = TaskBaseParams> {
     minWait: null,
     serialize: null,
     total: null,
+    page: null,
   };
 
   constructor(params: TTaskType, page: BrowserPage) {
@@ -22,8 +23,8 @@ export abstract class Task<TTaskType = TaskBaseParams> {
   }
 
   async close(): Promise<void> {
-    await this.page.page?.close();
-    await this.page.context?.close();
+    this.metrics.page = await this.page.metrics();
+    await this.page.close();
   }
 
   abstract process(): Promise<void>;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -55,6 +55,19 @@ export interface Metrics {
   minWait: number | null;
   serialize: number | null;
   total: number | null;
+  page: PageMetrics | null;
+}
+
+export interface PageMetrics {
+  layoutDuration: number | null;
+  scriptDuration: number | null;
+  taskDuration: number | null;
+  jsHeapUsedSize: number | null; // currently active to render the page
+  jsHeapTotalSize: number | null; // total allocated
+  requests: number;
+  blockedRequests: number;
+  contentLength: number;
+  contentLengthTotal: number;
 }
 
 export interface NewPage {


### PR DESCRIPTION
- Expose more metrics in the API 
  Coming from chrome directly
  
- Add a few missing tests about metrics and requests blocking
- Missing page close (Next PR I'll find a way to test fro memory leak and page opened to be sure we don't forget to close them)