### PR TITLE
fix(login): ignore aria-hidden password fields

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -104,7 +104,7 @@
         </div>
         <div class="stl-mt-2">
           <label for="renderHTML">Render HTML</label>
-          <input class="stl-mx-4" type="checkbox" id="renderHTML" name="renderHTML">
+          <input class="stl-mx-4" type="checkbox" id="renderHTML" name="renderHTML" value="true">
         </div>
 
         <div class="stl-mt-4">

--- a/src/api/routes/login.ts
+++ b/src/api/routes/login.ts
@@ -15,7 +15,7 @@ export async function validate(
     ...getDefaultParams(),
     username: alt.string().required(),
     password: alt.string().required(),
-    renderHTML: alt.boolean(),
+    renderHTML: alt.string(),
   })
     .body(req.body)
     .validate();
@@ -37,7 +37,7 @@ export async function processLogin(
       ua: string;
       username: string;
       password: string;
-      renderHTML?: boolean;
+      renderHTML?: string;
     }
   >,
   res: express.Response

--- a/src/api/routes/login.ts
+++ b/src/api/routes/login.ts
@@ -15,7 +15,7 @@ export async function validate(
     ...getDefaultParams(),
     username: alt.string().required(),
     password: alt.string().required(),
-    renderHTML: alt.string(),
+    renderHTML: alt.boolean().cast(),
   })
     .body(req.body)
     .validate();
@@ -37,7 +37,7 @@ export async function processLogin(
       ua: string;
       username: string;
       password: string;
-      renderHTML?: string;
+      renderHTML?: boolean;
     }
   >,
   res: express.Response

--- a/src/lib/tasks/Login.ts
+++ b/src/lib/tasks/Login.ts
@@ -39,7 +39,7 @@ export class LoginTask extends Task<LoginTaskParams> {
       console.log('No password input found: validating username...');
       try {
         await Promise.all([
-          page!.waitForNavigation(), // Doesn't work with Okta for example, it's JS based
+          // page!.waitForNavigation(), // Doesn't work with Okta for example, it's JS based
           page!.waitForSelector(
             'input[type=password]:not([aria-hidden="true"])',
             {

--- a/src/lib/tasks/Login.ts
+++ b/src/lib/tasks/Login.ts
@@ -28,21 +28,30 @@ export class LoginTask extends Task<LoginTaskParams> {
       return;
     }
 
+    console.log(`Current URL: ${page!.url()}`);
+    console.log('Entering username...');
     await textInput.type(login!.username);
 
-    let passwordInput = await page!.$('input[type=password]');
+    let passwordInput = await page!.$(
+      'input[type=password]:not([aria-hidden="true"])'
+    );
     if (!passwordInput) {
-      console.log('2 step login: validating username...');
+      console.log('No password input found: validating username...');
       try {
         await Promise.all([
-          // page.waitForNavigation(), // Doesn't work with Okta for example, it's JS based
-          page!.waitForSelector('input[type=password]', {
-            timeout: waitTime!.max!,
-          }),
+          page!.waitForNavigation(), // Doesn't work with Okta for example, it's JS based
+          page!.waitForSelector(
+            'input[type=password]:not([aria-hidden="true"])',
+            {
+              timeout: waitTime!.max!,
+            }
+          ),
           textInput!.press('Enter'),
         ]);
-        console.log(`2 step login: navigated to ${page!.url()}`);
-        passwordInput = await page!.$('input[type=password]');
+        console.log(`Current URL: ${page!.url()}`);
+        passwordInput = await page!.$(
+          'input[type=password]:not([aria-hidden="true"])'
+        );
       } catch (err) {
         console.log('Found no password input on the page');
         const body = await this.page.renderBody(new URL(page!.url()));
@@ -55,7 +64,7 @@ export class LoginTask extends Task<LoginTaskParams> {
       }
     }
 
-    console.log('Logging in...');
+    console.log('Entering password and logging in...');
     await passwordInput!.type(login!.password);
     let loginResponse;
     try {


### PR DESCRIPTION
Some JS based login forms require 2-steps (validating username, then password), but have the password field already present in the first step, hidden.
So the current selector (`input[type=password]`) was detecting this field and was trying to perform a 1-step login.

### Changes:

- Ignore the `aria-hidden` password fields.
- Fixed the `renderHTML` type, as HTML checkboxes don't send a boolean but a string value.