### PR TITLE
fix: test max wait

### DIFF
--- a/public/test-website/slow.html
+++ b/public/test-website/slow.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+</head>
+
+<body>
+  <div id="id"></div>
+  <script>
+    let i = 1;
+    setInterval(async () => {
+      i += 1;
+
+      // Do a fetch to block networkidle0
+      await fetch('http://localhost/test-website/async.html');
+
+      document.getElementById('id').appendChild(`<div>${i}</div>`);
+    }, 100);
+  </script>
+</body>
+
+</html>

--- a/public/test-website/slow.html
+++ b/public/test-website/slow.html
@@ -14,9 +14,9 @@
 
       document.getElementById('id').append('.');
       document.getElementById('count').innerHTML = i;
-      // Do a fetch to block networkidle0
       try {
-        // await fetch('http://localhost/test-website/async.html');
+        // Do a fetch to block networkidle0
+        await fetch('http://localhost/test-website/async.html');
       } catch (e) { }
     }, 200);
   </script>

--- a/public/test-website/slow.html
+++ b/public/test-website/slow.html
@@ -5,17 +5,20 @@
 </head>
 
 <body>
+  <div id="count"></div>
   <div id="id"></div>
   <script>
     let i = 1;
     setInterval(async () => {
       i += 1;
 
+      document.getElementById('id').append('.');
+      document.getElementById('count').innerHTML = i;
       // Do a fetch to block networkidle0
-      await fetch('http://localhost/test-website/async.html');
-
-      document.getElementById('id').appendChild(`<div>${i}</div>`);
-    }, 100);
+      try {
+        // await fetch('http://localhost/test-website/async.html');
+      } catch (e) { }
+    }, 200);
   </script>
 </body>
 

--- a/src/__tests__/async.test.ts
+++ b/src/__tests__/async.test.ts
@@ -58,8 +58,7 @@ describe('async', () => {
 
     const json = JSON.parse(body);
     expect(res.statusCode).toBe(200);
-    expect(json.metrics.total).toBeGreaterThanOrEqual(6000);
-    expect(json.metrics.total).toBeLessThanOrEqual(7000);
+    expect(json.metrics.total).toBeLessThanOrEqual(6000);
     expect(json.body).toMatch('5. setTimeout 5000');
   });
 
@@ -70,15 +69,17 @@ describe('async', () => {
         'content-type': 'application/json',
       },
       body: JSON.stringify({
-        url: 'http://localhost:3000/test-website/async.html',
+        url: 'http://localhost:3000/test-website/slow.html',
         ua: 'Algolia Crawler',
         waitTime: {
-          min: 5000,
+          min: 4000,
+          max: 5000,
         },
       }),
     });
 
     const json = JSON.parse(body);
+    console.log(json, json.body);
     expect(res.statusCode).toBe(200);
     expect(json.metrics.total).toBeGreaterThanOrEqual(6000);
     expect(json.metrics.total).toBeLessThanOrEqual(7000);

--- a/src/__tests__/async.test.ts
+++ b/src/__tests__/async.test.ts
@@ -85,8 +85,11 @@ describe('async', () => {
     expect(json.metrics.goto).toBeGreaterThan(5000);
 
     // We count the dot because there is no way to have precise execution
+    // There should be around 25 dots (one fetch every 200ms during 5s = 25 dots)
+    // We check for 20 to have some margin
+    // And no more than 30 to check that it was not executed more than 5s
     expect(json.body).toMatch('.'.repeat(20));
-    console.log(json.body);
+    expect(json.body).not.toMatch('.'.repeat(30));
   });
 });
 

--- a/src/__tests__/async.test.ts
+++ b/src/__tests__/async.test.ts
@@ -79,11 +79,11 @@ describe('async', () => {
     });
 
     const json = JSON.parse(body);
-    console.log(json, json.body);
     expect(res.statusCode).toBe(200);
-    expect(json.metrics.total).toBeGreaterThanOrEqual(6000);
-    expect(json.metrics.total).toBeLessThanOrEqual(7000);
-    expect(json.body).toMatch('5. setTimeout 5000');
+    expect(json.metrics.goto).toBeLessThanOrEqual(5010);
+    expect(json.metrics.goto).toBeGreaterThan(5000);
+    expect(json.body).toMatch('.'.repeat(20));
+    console.log(json.body);
   });
 });
 

--- a/src/__tests__/async.test.ts
+++ b/src/__tests__/async.test.ts
@@ -58,7 +58,8 @@ describe('async', () => {
 
     const json = JSON.parse(body);
     expect(res.statusCode).toBe(200);
-    expect(json.metrics.total).toBeLessThanOrEqual(6000);
+    expect(json.metrics.total).toBeGreaterThanOrEqual(6000);
+    expect(json.metrics.total).toBeLessThanOrEqual(7000);
     expect(json.body).toMatch('5. setTimeout 5000');
   });
 
@@ -82,6 +83,8 @@ describe('async', () => {
     expect(res.statusCode).toBe(200);
     expect(json.metrics.goto).toBeLessThanOrEqual(5010);
     expect(json.metrics.goto).toBeGreaterThan(5000);
+
+    // We count the dot because there is no way to have precise execution
     expect(json.body).toMatch('.'.repeat(20));
     console.log(json.body);
   });

--- a/src/__tests__/async.test.ts
+++ b/src/__tests__/async.test.ts
@@ -62,6 +62,28 @@ describe('async', () => {
     expect(json.metrics.total).toBeLessThanOrEqual(7000);
     expect(json.body).toMatch('5. setTimeout 5000');
   });
+
+  it('should wait 5000ms', async () => {
+    const { res, body } = await request('http://localhost:3000/render', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        url: 'http://localhost:3000/test-website/async.html',
+        ua: 'Algolia Crawler',
+        waitTime: {
+          min: 5000,
+        },
+      }),
+    });
+
+    const json = JSON.parse(body);
+    expect(res.statusCode).toBe(200);
+    expect(json.metrics.total).toBeGreaterThanOrEqual(6000);
+    expect(json.metrics.total).toBeLessThanOrEqual(7000);
+    expect(json.body).toMatch('5. setTimeout 5000');
+  });
 });
 
 describe('redirects', () => {

--- a/src/api/helpers/errors.ts
+++ b/src/api/helpers/errors.ts
@@ -29,12 +29,3 @@ export function badRequest({
     details,
   });
 }
-
-export class FetchError extends Error {
-  timeout: boolean;
-
-  constructor(msg: string, timeout: boolean = false) {
-    super(msg);
-    this.timeout = timeout;
-  }
-}

--- a/src/lib/browser/Page.ts
+++ b/src/lib/browser/Page.ts
@@ -114,6 +114,7 @@ export class BrowserPage {
 
     const start = Date.now();
     try {
+      // Response can be assigned here or on('response')
       response = await this.#page!.goto(url.href, {
         timeout,
         waitUntil: ['domcontentloaded', 'networkidle0'],
@@ -122,7 +123,7 @@ export class BrowserPage {
       // This error is expected has most page will reach timeout
       if (err.message.match(/Navigation timeout/)) {
         this.#hasTimeout = true;
-        throw new FetchError('timeout', true);
+        report(new FetchError('timeout', true), { url: url.href });
       }
 
       report(new Error('Loading error'), { err });

--- a/src/lib/browser/constants.ts
+++ b/src/lib/browser/constants.ts
@@ -6,6 +6,8 @@ export const RESPONSE_IGNORED_ERRORS = [
   'Request content was evicted from inspector cache',
   // Protocol error, js redirect or options
   'This might happen if the request is a preflight request',
+  // Can happen if the page that trigger this response was closed in the meantime
+  'Target closed.',
 ];
 
 export const REQUEST_IGNORED_ERRORS = ['Request is already handled'];


### PR DESCRIPTION
- We wrongly throwed on timeout while it was perfectly expected
- Ignore errors if page has timeout. It seems we can receive response (of other network request), after the page has been closed. Seems weird but that's my interpretation. 
- Add a test that ensure we wait for a timeout and has the appropriate content. This missing test could have saved me some trouble.