### PR TITLE
fix: simple solution for redirection

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,4 +6,5 @@ module.exports = {
   testMatch: ['<rootDir>/src/**/*.test.[jt]s'],
   globalSetup: '<rootDir>/jest.setup.ts',
   setupFiles: ['dotenv/config'],
+  maxWorkers: 1,
 };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "release": "yarn docker:build && yarn docker:release",
     "start": "UV_THREADPOOL_SIZE=100 node dist/index.js",
     "semantic-release": "semantic-release",
-    "test": "jest --runInBand src/"
+    "test": "jest src/"
   },
   "repository": {
     "type": "git",

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -1,21 +1,15 @@
 import type { PostRenderSuccess } from 'api/@types/postRender';
 
-import { request } from './helpers';
+import { postRender } from './helpers';
 
 /**
  * Test the schema only on this file.
  */
 describe('POST /render', () => {
   it('should validate 200', async () => {
-    const { res, body } = await request('http://localhost:3000/render', {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({
-        url: 'http://localhost:3000/test-website/async.html',
-        ua: 'Algolia Crawler',
-      }),
+    const { res, body } = await postRender({
+      url: 'http://localhost:3000/test-website/async.html',
+      ua: 'Algolia Crawler',
     });
     expect(res.statusCode).toBe(200);
 

--- a/src/__tests__/async.test.ts
+++ b/src/__tests__/async.test.ts
@@ -1,6 +1,6 @@
 import type { PostRenderSuccess } from 'api/@types/postRender';
 
-import { cleanString, request } from './helpers';
+import { cleanString, postRender, request } from './helpers';
 
 jest.setTimeout(10000);
 
@@ -26,15 +26,9 @@ describe('async', () => {
   });
 
   it('should wait by default for 0ms', async () => {
-    const { res, body } = await request('http://localhost:3000/render', {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({
-        url: 'http://localhost:3000/test-website/async.html',
-        ua: 'Algolia Crawler',
-      }),
+    const { res, body } = await postRender({
+      url: 'http://localhost:3000/test-website/async.html',
+      ua: 'Algolia Crawler',
     });
 
     const json: PostRenderSuccess = JSON.parse(body);
@@ -44,18 +38,12 @@ describe('async', () => {
   });
 
   it('should wait at least 6000ms', async () => {
-    const { res, body } = await request('http://localhost:3000/render', {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
+    const { res, body } = await postRender({
+      url: 'http://localhost:3000/test-website/async.html',
+      ua: 'Algolia Crawler',
+      waitTime: {
+        min: 6000,
       },
-      body: JSON.stringify({
-        url: 'http://localhost:3000/test-website/async.html',
-        ua: 'Algolia Crawler',
-        waitTime: {
-          min: 6000,
-        },
-      }),
     });
 
     const json: PostRenderSuccess = JSON.parse(body);
@@ -68,19 +56,13 @@ describe('async', () => {
   });
 
   it('should wait at most 5000ms', async () => {
-    const { res, body } = await request('http://localhost:3000/render', {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
+    const { res, body } = await postRender({
+      url: 'http://localhost:3000/test-website/slow.html',
+      ua: 'Algolia Crawler',
+      waitTime: {
+        min: 4000,
+        max: 5000,
       },
-      body: JSON.stringify({
-        url: 'http://localhost:3000/test-website/slow.html',
-        ua: 'Algolia Crawler',
-        waitTime: {
-          min: 4000,
-          max: 5000,
-        },
-      }),
     });
 
     const json: PostRenderSuccess = JSON.parse(body);

--- a/src/__tests__/blockedRequests.test.ts
+++ b/src/__tests__/blockedRequests.test.ts
@@ -1,20 +1,14 @@
 import type { PostRenderSuccess } from 'api/@types/postRender';
 
-import { request } from './helpers';
+import { postRender } from './helpers';
 
 jest.setTimeout(10000);
 
 describe('native', () => {
   it('should block basic unecessary requests', async () => {
-    const { res, body } = await request('http://localhost:3000/render', {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({
-        url: 'http://localhost:3000/test-website/blocked-requests.html',
-        ua: 'Algolia Crawler',
-      }),
+    const { res, body } = await postRender({
+      url: 'http://localhost:3000/test-website/blocked-requests.html',
+      ua: 'Algolia Crawler',
     });
 
     const json: PostRenderSuccess = JSON.parse(body);
@@ -29,16 +23,10 @@ describe('native', () => {
 
 describe('adblocker', () => {
   it('should use adblock', async () => {
-    const { res, body } = await request('http://localhost:3000/render', {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({
-        url: 'http://localhost:3000/test-website/blocked-requests.html',
-        ua: 'Algolia Crawler',
-        adblock: true,
-      }),
+    const { res, body } = await postRender({
+      url: 'http://localhost:3000/test-website/blocked-requests.html',
+      ua: 'Algolia Crawler',
+      adblock: true,
     });
 
     const json: PostRenderSuccess = JSON.parse(body);

--- a/src/__tests__/login.real.test.ts
+++ b/src/__tests__/login.real.test.ts
@@ -14,7 +14,8 @@ const rawCreds = process.env.LOGIN_CREDENTIALS;
 const canExec = process.env.CI || rawCreds;
 
 jest.setTimeout(25000);
-// Not working right now
+
+// !--- Not working right now
 // eslint-disable-next-line jest/no-disabled-tests
 describe.skip('Real Login', () => {
   let creds: { [name: string]: { username: string; password: string } };

--- a/src/__tests__/redirect.test.ts
+++ b/src/__tests__/redirect.test.ts
@@ -1,21 +1,17 @@
 import type { PostRenderSuccess } from 'api/@types/postRender';
 
-import { cleanString, request } from './helpers';
+import { cleanString, postRender, request } from './helpers';
 
 describe('server redirect', () => {
   it('should return the redirection', async () => {
     // !---
     // Server Redirect are flaky since Playwright do not catch 301
     // You might want to relaunch the test if it failed.
-    const { res, body } = await request('http://localhost:3000/render', {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
+    const { res, body } = await postRender({
+      url: 'http://localhost:3000/301',
+      waitTime: {
+        min: 5000, // wait long to be sure we end up being redirected
       },
-      body: JSON.stringify({
-        url: 'http://localhost:3000/301',
-        ua: 'Algolia Crawler',
-      }),
     });
 
     const json: PostRenderSuccess = JSON.parse(body);
@@ -40,15 +36,9 @@ describe('server redirect', () => {
 
 describe('meta refresh', () => {
   it('should return the redirection', async () => {
-    const { res, body } = await request('http://localhost:3000/render', {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({
-        url: 'http://localhost:3000/test-website/meta-refresh.html',
-        ua: 'Algolia Crawler',
-      }),
+    const { res, body } = await postRender({
+      url: 'http://localhost:3000/test-website/meta-refresh.html',
+      ua: 'Algolia Crawler',
     });
 
     const json: PostRenderSuccess = JSON.parse(body);
@@ -68,19 +58,13 @@ describe('meta refresh', () => {
   });
 
   it('should return the redirection even if not executed yet', async () => {
-    const { res, body } = await request('http://localhost:3000/render', {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
+    const { res, body } = await postRender({
+      // The client redirection happens after 5sec but we only wait 2sec
+      url: 'http://localhost:3000/test-website/meta-refresh-5.html',
+      ua: 'Algolia Crawler',
+      waitTime: {
+        max: 2000,
       },
-      body: JSON.stringify({
-        // The client redirection happens after 5sec but we only wait 2sec
-        url: 'http://localhost:3000/test-website/meta-refresh-5.html',
-        ua: 'Algolia Crawler',
-        waitTime: {
-          max: 2000,
-        },
-      }),
     });
 
     const json: PostRenderSuccess = JSON.parse(body);
@@ -102,18 +86,12 @@ describe('meta refresh', () => {
 
 describe('js redirects', () => {
   it('should catch redirection', async () => {
-    const { res, body } = await request('http://localhost:3000/render', {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
+    const { res, body } = await postRender({
+      url: 'http://localhost:3000/test-website/js-redirect.html?to=/test-website/basic.html',
+      ua: 'Algolia Crawler',
+      waitTime: {
+        max: 2000,
       },
-      body: JSON.stringify({
-        url: 'http://localhost:3000/test-website/js-redirect.html?to=/test-website/basic.html',
-        ua: 'Algolia Crawler',
-        waitTime: {
-          max: 2000,
-        },
-      }),
     });
 
     const json: PostRenderSuccess = JSON.parse(body);

--- a/src/__tests__/tasksManager.test.ts
+++ b/src/__tests__/tasksManager.test.ts
@@ -1,6 +1,6 @@
 import type { GetHealthySuccess } from 'api/@types/getHealthy';
 
-import { request } from './helpers';
+import { postRender, request } from './helpers';
 
 describe('manager', () => {
   it('should properly close page after done', async () => {
@@ -17,15 +17,9 @@ describe('manager', () => {
     });
 
     // Process something
-    const { res: resRender } = await request('http://localhost:3000/render', {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({
-        url: 'http://localhost:3000/test-website/async.html',
-        ua: 'Algolia Crawler',
-      }),
+    const { res: resRender } = await postRender({
+      url: 'http://localhost:3000/test-website/async.html',
+      ua: 'Algolia Crawler',
     });
     expect(resRender.statusCode).toBe(200);
 

--- a/src/lib/browser/Page.ts
+++ b/src/lib/browser/Page.ts
@@ -45,6 +45,7 @@ export class BrowserPage {
   };
   #redirection?: string;
   #hasTimeout: boolean = false;
+  #initialResponse?: Response;
 
   get page(): Page | undefined {
     return this.#page;
@@ -64,6 +65,10 @@ export class BrowserPage {
 
   get redirection(): string | undefined {
     return this.#redirection;
+  }
+
+  get initialResponse(): Response | undefined {
+    return this.#initialResponse;
   }
 
   constructor(context: BrowserContext) {
@@ -179,6 +184,11 @@ export class BrowserPage {
    */
   async saveMetrics(): Promise<PageMetrics> {
     try {
+      if (!this.#page) {
+        // page has been closed or not yet open
+        return this.#metrics;
+      }
+
       const perf: {
         curr: PerformanceNavigationTiming;
         all: PerformanceEntryList;
@@ -403,6 +413,11 @@ export class BrowserPage {
       const reqUrl = res.url();
       const headers = await res.allHeaders();
       let length = 0;
+
+      // Store initial response in case of navigation
+      if (!this.#initialResponse) {
+        this.#initialResponse = res;
+      }
 
       if (headers['content-length']) {
         length = parseInt(headers['content-length'], 10);

--- a/src/lib/tasks/Render.ts
+++ b/src/lib/tasks/Render.ts
@@ -1,6 +1,5 @@
 import type { Response } from 'playwright-chromium';
 
-import { wait } from 'helpers/wait';
 import { injectBaseHref } from 'lib/helpers/injectBaseHref';
 import type { RenderTaskParams } from 'lib/types';
 

--- a/src/lib/tasks/Render.ts
+++ b/src/lib/tasks/Render.ts
@@ -1,5 +1,6 @@
 import type { Response } from 'playwright-chromium';
 
+import { wait } from 'helpers/wait';
 import { injectBaseHref } from 'lib/helpers/injectBaseHref';
 import type { RenderTaskParams } from 'lib/types';
 
@@ -44,7 +45,8 @@ export class RenderTask extends Task<RenderTaskParams> {
     await this.saveMetrics();
     this.setMetric('goto');
 
-    await this.saveStatus(response);
+    // In case of redirection, initialResponse is prefered since response is probably now incorrect
+    await this.saveStatus(this.page.initialResponse || response);
 
     if (this.page.redirection) {
       return;


### PR DESCRIPTION
Following #572 Redirection could still be flaky but I did not realised there was a perfect and simple solution.

- Store the initalResponse and reuse it instead of using the final response.
- Bonus: use postRender where it was not yet used