### PR TITLE
fix(docker): improve dockerfile size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,15 @@
-# Base image
-FROM ubuntu:focal
+ARG IMAGE_BASE=docker.io/algolia/renderscript-pw-chromium
 
-# For tzdata
-ARG DEBIAN_FRONTEND=noninteractive
-ARG TZ=America/Los_Angeles
+# ------------------
+# New final image
+FROM ${IMAGE_BASE} as base
 
-# Autolink repository https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
-LABEL org.opencontainers.image.source=https://github.com/algolia/renderscript
-LABEL org.opencontainers.image.revision=$VERSION
-
-# === INSTALL Node.js ===
-RUN apt-get update && \
-  # Install node16
-  apt-get install -y curl wget && \
-  curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
-  apt-get install -y nodejs && \
-  # Feature-parity with node.js base images.
-  apt-get install -y --no-install-recommends git openssh-client && \
-  npm install -g yarn && \
-  # clean apt cache
-  rm -rf /var/lib/apt/lists/* && \
-  # Create the pwuser
-  adduser pwuser
+ARG VERSION
+ENV VERSION ${VERSION:-dev}
+ENV NODE_ENV production
+ENV IN_DOCKER true
+ENV PLAYWRIGHT_BROWSERS_PATH="/ms-playwright"
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD="true"
 
 # Setup the app WORKDIR
 WORKDIR /app/tmp
@@ -30,31 +18,44 @@ WORKDIR /app/tmp
 # To leverage Docker's cache when no dependency has change
 COPY package.json yarn.lock .yarnrc.yml ./
 COPY .yarn .yarn
-RUN ls -lah /app/tmp
-ENV PLAYWRIGHT_BROWSERS_PATH="/app/tmp/pw-browsers"
-ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD="true"
 
 # Install dev dependencies
 RUN true \
   # Use local version instead of letting yarn auto upgrade itself
   && yarn set version $(ls -d $PWD/.yarn/releases/*) \
-  && yarn install \
-  && npx playwright install chromium \
-  && npx playwright install-deps chromium
+  && yarn install
 
 # This step will invalidates cache
 COPY . /app/tmp
-RUN ls -lah /app/tmp
-
-ARG VERSION
-ENV VERSION ${VERSION:-dev}
-ENV NODE_ENV production
-ENV IN_DOCKER true
 
 # Builds the UI, install chrome and remove dev dependencies
 RUN true \
+  && ls -lah /app/tmp \
   && yarn build \
   && yarn workspaces focus --all --production \
   && rm -rf .yarn/
+
+# ------------------
+# New final image
+FROM ${IMAGE_BASE} as final
+
+ARG VERSION
+ENV VERSION ${VERSION:-dev}
+
+# Autolink repository https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
+LABEL org.opencontainers.image.source=https://github.com/algolia/renderscript
+LABEL org.opencontainers.image.revision=$VERSION
+
+ENV NODE_ENV production
+ENV IN_DOCKER true
+ENV PLAYWRIGHT_BROWSERS_PATH="/ms-playwright"
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD="true"
+
+# Copy install from previous stage
+WORKDIR /app/renderscript
+COPY --from=base --chown=node:node /app/tmp /app/renderscript
+
+# Do not use root to run the app
+USER pwuser
 
 CMD [ "node", "dist/index.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG VERSION
 ARG IMAGE_BASE=docker.io/algolia/renderscript-pw-chromium:${VERSION}
 
 # ------------------
-# New final image
+# New base image
 FROM ${IMAGE_BASE} as base
 
 ENV VERSION ${VERSION:-dev}
@@ -36,7 +36,7 @@ RUN true \
   && rm -rf .yarn/
 
 # ------------------
-# New final image
+# New final image that onlys contains built code
 FROM ${IMAGE_BASE} as final
 
 ARG VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-ARG IMAGE_BASE=docker.io/algolia/renderscript-pw-chromium
+ARG VERSION
+ARG IMAGE_BASE=docker.io/algolia/renderscript-pw-chromium:${VERSION}
 
 # ------------------
 # New final image
 FROM ${IMAGE_BASE} as base
 
-ARG VERSION
 ENV VERSION ${VERSION:-dev}
 ENV NODE_ENV production
 ENV IN_DOCKER true

--- a/Dockerfile.pw
+++ b/Dockerfile.pw
@@ -1,0 +1,37 @@
+FROM ubuntu:focal as base
+
+ARG VERSION
+ENV VERSION ${VERSION:-dev}
+
+# Autolink repository https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
+LABEL org.opencontainers.image.source=https://github.com/algolia/renderscript
+LABEL org.opencontainers.image.revision=$VERSION
+
+# For tzdata
+ARG DEBIAN_FRONTEND=noninteractive
+ARG TZ=America/Los_Angeles
+
+# === INSTALL Node.js ===
+RUN apt-get update && \
+  # Install node16
+  apt-get install -y curl wget && \
+  curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
+  apt-get install -y nodejs && \
+  # Feature-parity with node.js base images.
+  apt-get install -y --no-install-recommends git openssh-client && \
+  npm install -g yarn && \
+  # clean apt cache
+  rm -rf /var/lib/apt/lists/* && \
+  # Create the pwuser
+  adduser pwuser
+
+# === BAKE BROWSERS INTO IMAGE ===
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+# Browsers will be downloaded in `/ms-playwright`.
+RUN mkdir /ms-playwright \
+  && npx playwright install chromium \
+  && npx playwright install-deps chromium \
+  # Clean cache
+  && rm -rf /var/lib/apt/lists/* \
+  && chmod -R 777 /ms-playwright

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -11,10 +11,12 @@ echo ""
 
 docker build \
   --progress plain \
-  -t algolia/renderscript-pw-chromium \
+  -t algolia/renderscript-pw-chromium:${current} \
   --build-arg "VERSION=${current}" \
   -f Dockerfile.pw \
   .
+
+# Build renderscript
 
 docker build \
   --progress plain \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,6 +7,15 @@ current=$(node -e "console.log(require('./package.json').version)")
 echo "Releasing: $current"
 echo ""
 
+# Build base image
+
+docker build \
+  --progress plain \
+  -t algolia/renderscript-pw-chromium \
+  --build-arg "VERSION=${current}" \
+  -f Dockerfile.pw \
+  .
+
 docker build \
   --progress plain \
   -t algolia/renderscript \

--- a/scripts/push.sh
+++ b/scripts/push.sh
@@ -8,6 +8,8 @@ current=$(node -e "console.log(require('./package.json').version)")
 echo "Pushing: $current"
 echo ""
 
+docker push "algolia/renderscript-pw-chromium:${current}"
+
 docker push "algolia/renderscript"
 docker push "algolia/renderscript:${current}"
 docker push "algolia/renderscript:${hash}"

--- a/src/api/helpers/buildUrl.ts
+++ b/src/api/helpers/buildUrl.ts
@@ -1,5 +1,7 @@
 const DOCKER_LOCALHOST = 'host.docker.internal';
 
+const USE_DOCKER_LOCALHOST = process.env.USE_DOCKER_LOCALHOST === 'true';
+
 export function replaceHost(url: URL, from: string, to: string): URL {
   const fromRegex = new RegExp(`^${from}(:|$)`);
   const host = url.host || '';
@@ -10,12 +12,16 @@ export function replaceHost(url: URL, from: string, to: string): URL {
 
 export function revertUrl(href: string): URL {
   const url = new URL(href);
-  if (process.env.USE_DOCKER_LOCALHOST !== 'true') return url;
+  if (!USE_DOCKER_LOCALHOST) {
+    return url;
+  }
   return replaceHost(url, DOCKER_LOCALHOST, 'localhost');
 }
 
 export function buildUrl(href: string): URL {
   const url = new URL(href);
-  if (process.env.USE_DOCKER_LOCALHOST !== 'true') return url;
+  if (!USE_DOCKER_LOCALHOST) {
+    return url;
+  }
   return replaceHost(url, 'localhost', DOCKER_LOCALHOST);
 }

--- a/src/api/routes/render.ts
+++ b/src/api/routes/render.ts
@@ -97,7 +97,7 @@ export async function renderJSON(
       body: task.body,
       headers: task.headers,
       metrics: task.metrics,
-      resolvedUrl: task.resolvedUrl,
+      resolvedUrl: task.resolvedUrl ? revertUrl(task.resolvedUrl).href : null,
       statusCode: task.statusCode,
       timeout: task.timeout,
       error: task.error,

--- a/src/api/routes/render.ts
+++ b/src/api/routes/render.ts
@@ -7,7 +7,7 @@ import type {
 import type { Res500 } from 'api/@types/responses';
 import { CSP_HEADERS } from 'api/constants';
 import { getDefaultParams, alt } from 'api/helpers/alt';
-import { revertUrl } from 'api/helpers/buildUrl';
+import { buildUrl, revertUrl } from 'api/helpers/buildUrl';
 import { badRequest } from 'api/helpers/errors';
 import { getForwardedHeadersFromRequest } from 'api/helpers/getForwardedHeaders';
 import { report } from 'helpers/errorReporting';
@@ -37,7 +37,7 @@ export async function render(
 ): Promise<void> {
   const { url: rawUrl, ua, waitTime, adblock } = req.query;
   const headersToForward = getForwardedHeadersFromRequest(req);
-  const url = new URL(rawUrl);
+  const url = new URL(buildUrl(rawUrl));
 
   try {
     const { error, statusCode, body, resolvedUrl } = await tasksManager.task(
@@ -80,7 +80,7 @@ export async function renderJSON(
 ): Promise<void> {
   const { url: rawUrl, ua, waitTime, adblock } = req.body;
   const headersToForward = getForwardedHeadersFromRequest(req);
-  const url = new URL(rawUrl);
+  const url = new URL(buildUrl(rawUrl));
 
   try {
     const task = await tasksManager.task(

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,10 @@ process.on('uncaughtException', (reason) => {
 });
 
 (async (): Promise<void> => {
-  log.info('Starting...', { env: process.env.NODE_ENV });
+  log.info('Starting...', {
+    env: process.env.NODE_ENV,
+    v: process.env.VERSION,
+  });
 
   const api = new Api();
   api.start(PORT);

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -77,17 +77,15 @@ export const IGNORED_RESOURCES = [
   'manifest',
   'texttrack',
 ];
-export const PAGE_BUFFER_SIZE = 2;
-export const DATA_REGEXP = /^data:/i;
 
-export const MAX_RENDERER_TASKS = 256;
+export const DATA_REGEXP = /^data:/i;
 
 export const WAIT_TIME = {
   min: 500,
   max: 20000,
 };
 
-export const UNHEALTHY_TASK_TTL = 21 * 1000;
+export const UNHEALTHY_TASK_TTL = 30 * 1000;
 
 export const MAX_WAIT_FOR_NEW_PAGE = process.env.MAX_WAIT_FOR_NEW_PAGE
   ? parseInt(process.env.MAX_WAIT_FOR_NEW_PAGE, 10)


### PR DESCRIPTION
Renderscript image wasn't optimised at all (+ it was segfaulting)
Made a 3 stages dockerfile
- 1st stage: Playwright only chromium
- 2nd stage: Code + npm install dev
- 3rd stage: Only built code

This results in an acceptable **533.49 MB compressed** image.

```sh
./scripts/build.sh

docker run -p 23000:3000 docker.io/algolia/renderscript
```

Bonus: missing buildUrl/revertUrl for localhost testing.