### PR TITLE
fix(actions): build docker only on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Release
         run: |
           yarn install
-          yarn semantic-release --dry-run
+          yarn semantic-release

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -1,17 +1,15 @@
 name: Release Docker
 on:
-  workflow_run:
-    workflows: ["Release Version"]
-    branches: [master]
-    types:
-      - completed
+  release:
+    types: [published]
 
   workflow_dispatch:
     inputs:
-      is_release:
+      dry_run:
         required: true
         type: boolean
-        description: "Is this a release image?"
+        default: 'true'
+        description: 'DryRun?'
 
 env:
   COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -71,7 +69,7 @@ jobs:
 
       # Cache should be reused from prev execution
       - name: Push
-        if: (github.ref == 'refs/heads/master') || (github.event_name == 'workflow_dispatch' && github.event.inputs.is_release == 'true')
+        if: (github.ref == 'refs/heads/master') || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true')
         uses: docker/build-push-action@v2
         with:
           file: Dockerfile


### PR DESCRIPTION
Github Actions setup works:
- semantic-release seems to work, removing the dry-run mode
- build docker on the release commit only so we don't need to mess with git during the CI