### PR TITLE
fix: improve errors reporting

### DIFF
--- a/src/api/@types/postRender.ts
+++ b/src/api/@types/postRender.ts
@@ -1,3 +1,4 @@
+import type { HandledError, UnhandledError } from 'lib/helpers/errors';
 import type { Metrics, TaskBaseParams } from 'lib/types';
 
 import type { Res500 } from './responses';
@@ -49,5 +50,5 @@ export interface PostRenderSuccess {
    * Any error encountered along the way.
    * If this field is filled that means the rest of the payload is partial.
    */
-  error: string | null;
+  error: HandledError | UnhandledError | null;
 }

--- a/src/api/routes/healthy.ts
+++ b/src/api/routes/healthy.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import type express from 'express';
 
 import type { GetHealthySuccess } from 'api/@types/getHealthy';
+import { log } from 'helpers/logger';
 import { stats } from 'helpers/stats';
 import { tasksManager } from 'lib/singletons';
 
@@ -28,6 +29,15 @@ export function healthy(
       hostname,
     }
   );
+
+  if (!isHealthy) {
+    log.error({
+      err: 'Reporting not healthy',
+      tasksRunning,
+      pagesOpen,
+      totalRun,
+    });
+  }
 
   res
     .status(isHealthy ? 200 : 503)

--- a/src/helpers/errorReporting.ts
+++ b/src/helpers/errorReporting.ts
@@ -13,7 +13,7 @@ Sentry.init({
 
 export function report(err: Error, extra: any = {}): void {
   if (!process.env.SENTRY_DSN) {
-    log.error(err.message, err.stack, extra);
+    log.error({ err, extra });
     return;
   }
 

--- a/src/lib/TasksManager.ts
+++ b/src/lib/TasksManager.ts
@@ -4,6 +4,7 @@ import { stats } from 'helpers/stats';
 
 import { Browser } from './browser/Browser';
 import { UNHEALTHY_TASK_TTL } from './constants';
+import { cleanErrorMessage } from './helpers/errors';
 import type { Task } from './tasks/Task';
 import type { TaskObject, TaskFinal } from './types';
 
@@ -98,6 +99,16 @@ export class TasksManager {
     try {
       await task.createContext(this.#browser);
       await task.process();
+    } catch (err: any) {
+      // eslint-disable-next-line no-param-reassign
+      task.results.error = cleanErrorMessage(err);
+      if (task.results.error === 'unknown_error') {
+        // Task itself should never break the whole execution
+        report(err, { url });
+      }
+    }
+
+    try {
       await task.saveMetrics();
     } catch (err: any) {
       // Task itself should never break the whole execution

--- a/src/lib/browser/Page.ts
+++ b/src/lib/browser/Page.ts
@@ -1,3 +1,10 @@
+import type {
+  BrowserContext,
+  Page,
+  Route,
+  Response,
+} from 'playwright-chromium';
+
 import { report } from 'helpers/errorReporting';
 import { log } from 'helpers/logger';
 import { stats } from 'helpers/stats';
@@ -5,12 +12,6 @@ import { cleanErrorMessage } from 'lib/helpers/errors';
 import { isURLAllowed } from 'lib/helpers/validateURL';
 import { adblocker } from 'lib/singletons';
 import type { PageMetrics, TaskBaseParams } from 'lib/types';
-import type {
-  BrowserContext,
-  Page,
-  Route,
-  Response,
-} from 'playwright-chromium';
 
 import { DATA_REGEXP, IGNORED_RESOURCES } from '../constants';
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -85,8 +85,8 @@ export const WAIT_TIME = {
   max: 20000,
 };
 
-export const UNHEALTHY_TASK_TTL = 30 * 1000;
-
 export const MAX_WAIT_FOR_NEW_PAGE = process.env.MAX_WAIT_FOR_NEW_PAGE
   ? parseInt(process.env.MAX_WAIT_FOR_NEW_PAGE, 10)
   : 6000; // In feb 2022 p95 < 6s
+
+export const UNHEALTHY_TASK_TTL = (MAX_WAIT_FOR_NEW_PAGE + WAIT_TIME.max) * 2;

--- a/src/lib/helpers/errors.ts
+++ b/src/lib/helpers/errors.ts
@@ -1,6 +1,6 @@
 export type HandledError =
   | 'dns_error'
-  | 'fetch_abort'
+  | 'fetch_aborted'
   | 'fetch_timeout'
   | 'page_closed_too_soon';
 export type UnhandledError = 'unknown_error';
@@ -13,7 +13,7 @@ export function cleanErrorMessage(error: Error): HandledError | UnhandledError {
     return 'dns_error';
   }
   if (error.message.includes('ERR_ABORTED')) {
-    return 'fetch_abort';
+    return 'fetch_aborted';
   }
   if (
     error.message.includes('ETIMEDOUT') ||

--- a/src/lib/helpers/errors.ts
+++ b/src/lib/helpers/errors.ts
@@ -1,4 +1,11 @@
-export function cleanErrorMessage(error: Error): string {
+export type HandledError =
+  | 'dns_error'
+  | 'fetch_abort'
+  | 'fetch_timeout'
+  | 'page_closed_too_soon';
+export type UnhandledError = 'unknown_error';
+
+export function cleanErrorMessage(error: Error): HandledError | UnhandledError {
   if (error.message.includes('ERR_NAME_NOT_RESOLVED')) {
     return 'dns_error';
   }
@@ -8,8 +15,17 @@ export function cleanErrorMessage(error: Error): string {
   if (error.message.includes('ERR_ABORTED')) {
     return 'fetch_abort';
   }
-  if (error.message.includes('ETIMEDOUT' || 'ESOCKETTIMEDOUT')) {
+  if (
+    error.message.includes('ETIMEDOUT') ||
+    error.message.includes('ESOCKETTIMEDOUT')
+  ) {
     return 'fetch_timeout';
+  }
+  if (
+    error.message.includes('Navigation failed because page was closed') ||
+    error.message.includes('Target closed')
+  ) {
+    return 'page_closed_too_soon';
   }
 
   return `unknown_error`;

--- a/src/lib/tasks/Render.ts
+++ b/src/lib/tasks/Render.ts
@@ -1,5 +1,6 @@
 import type { Response } from 'playwright-chromium';
 
+import { wait } from 'helpers/wait';
 import { cleanErrorMessage } from 'lib/helpers/errors';
 import { injectBaseHref } from 'lib/helpers/injectBaseHref';
 import type { RenderTaskParams } from 'lib/types';
@@ -27,7 +28,7 @@ export class RenderTask extends Task<RenderTaskParams> {
       await this.page?.saveMetrics();
 
       // Hard close of the page to avoid reaching the backend
-      await this.page?.page?.close();
+      await this.page?.close();
     });
 
     try {

--- a/src/lib/tasks/Render.ts
+++ b/src/lib/tasks/Render.ts
@@ -1,6 +1,5 @@
 import type { Response } from 'playwright-chromium';
 
-import { wait } from 'helpers/wait';
 import { cleanErrorMessage } from 'lib/helpers/errors';
 import { injectBaseHref } from 'lib/helpers/injectBaseHref';
 import type { RenderTaskParams } from 'lib/types';


### PR DESCRIPTION
- Catch all `Target Closed`, they happen either if the page has crashed (unlikely) or the page was closed (happen on navigation or service close) so either way it's perfectly expected we don't need to report them.
- Type errors returned in the API
- Log error when service report unhealthy and increase the default unhealthy period.