### PR TITLE
fix(login): catch more errors

### DIFF
--- a/src/__tests__/login.test.ts
+++ b/src/__tests__/login.test.ts
@@ -113,12 +113,15 @@ describe('login', () => {
 
     expect(res.statusCode).toBe(200);
 
-    const cookies: Cookie[] = JSON.parse(body).cookies;
+    const parsed: PostLoginSuccess = JSON.parse(body);
+    expect(parsed.cookies).toHaveLength(1);
     expect(
-      cookies.find((cookie) => cookie.name === 'sessionToken')
+      parsed.cookies.find((cookie) => cookie.name === 'sessionToken')
     ).toBeUndefined();
     // Check that we actually went through the form
-    expect(cookies.find((cookie) => cookie.name === '_csrf')).toBeDefined();
+    expect(
+      parsed.cookies.find((cookie) => cookie.name === '_csrf')
+    ).toBeDefined();
   });
 });
 

--- a/src/api/@types/postLogin.ts
+++ b/src/api/@types/postLogin.ts
@@ -45,6 +45,7 @@ export interface PostLoginSuccess {
    * If this field is filled that means the rest of the payload is partial.
    */
   error: string | null;
+  rawError: { message: string; stack?: string } | null;
 
   /**
    * Cookie generated from a succesful login.

--- a/src/lib/helpers/errors.ts
+++ b/src/lib/helpers/errors.ts
@@ -5,8 +5,11 @@ export const retryableErrors: Array<HandledError | UnhandledError> = [
   'connection_error',
   'fetch_aborted',
   'fetch_timeout',
+  'no_cookies',
+  'no_response_after_login',
   'page_closed_too_soon',
   'page_crashed',
+  'timedout',
   'unknown_error',
 ];
 
@@ -44,7 +47,9 @@ export function cleanErrorMessage(error: Error): HandledError | UnhandledError {
   }
   if (
     error.message.includes('goto_no_response') ||
-    error.message.includes('ERR_FAILED')
+    error.message.includes('Navigation failed because page crashed') ||
+    error.message.includes('ERR_FAILED') ||
+    error.message.includes('Element is not attached to the DOM')
   ) {
     return 'page_crashed';
   }

--- a/src/lib/tasks/Login.ts
+++ b/src/lib/tasks/Login.ts
@@ -154,7 +154,7 @@ export class LoginTask extends Task<LoginTaskParams> {
         // And wait for a new input to be there maybe
         // page!.waitForNavigation() doesn't work with Okta for example, it's JS based
         await this.page!.ref?.waitForSelector(inputSel, {
-          timeout: this.timeBudget.limit(1000),
+          timeout: this.timeBudget.limit(3000),
         });
         this.timeBudget.consume();
 
@@ -164,7 +164,7 @@ export class LoginTask extends Task<LoginTaskParams> {
       }
 
       if (!passwordInputLoc || (await passwordInputLoc.count()) <= 0) {
-        // Can't definitely not find a password input
+        // Can definitely not find a password input
         this.results.error = 'field_not_found';
         this.results.rawError = new Error(inputSel);
         return;
@@ -211,7 +211,7 @@ export class LoginTask extends Task<LoginTaskParams> {
         }),
         passwordInput.press('Enter', {
           noWaitAfter: true,
-          timeout: this.timeBudget.limit(1000),
+          timeout: this.timeBudget.limit(3000),
         }),
       ]);
     } catch (err: any) {

--- a/src/lib/tasks/Login.ts
+++ b/src/lib/tasks/Login.ts
@@ -1,4 +1,9 @@
-import type { ElementHandle, Response, Request } from 'playwright-chromium';
+import type {
+  ElementHandle,
+  Response,
+  Request,
+  Locator,
+} from 'playwright-chromium';
 
 import { report } from 'helpers/errorReporting';
 import { cleanErrorMessage } from 'lib/helpers/errors';
@@ -13,8 +18,7 @@ export class LoginTask extends Task<LoginTaskParams> {
     }
 
     /* Setup */
-    const { url, login } = this.params;
-    const log = this.log;
+    const { url } = this.params;
     let response: Response;
 
     try {
@@ -31,42 +35,25 @@ export class LoginTask extends Task<LoginTaskParams> {
     await this.saveStatus(response);
 
     // We first check if there is form
-    const textInputLoc = this.page.ref?.locator(
-      'input[type=text], input[type=email]'
-    );
-    if (!textInputLoc || (await textInputLoc.count()) <= 0) {
-      this.results.error = 'field_not_found';
-      this.results.rawError = new Error('input[type=text], input[type=email]');
+    const usernameInputLoc = await this.#checkForm();
+    if (this.results.error || !usernameInputLoc) {
       return;
     }
 
-    log.debug('Current URL', { pageUrl: this.page.ref?.url() });
-    log.info('Entering username...', { userName: login.username });
-    const elTextInput = (await textInputLoc.elementHandle())!;
-    await elTextInput.type(login.username, {
-      noWaitAfter: true,
-      timeout: this.timeBudget.get(),
-    });
-    this.timeBudget.consume();
+    const usernameInput = await this.#typeUsername(usernameInputLoc);
+    if (this.results.error || !usernameInput) {
+      return;
+    }
 
     // Get the password input
-    const passwordInput = await this.#getPasswordInput(elTextInput);
-    if (!passwordInput) {
-      await this.saveStatus(response);
-
+    const passwordInput = await this.#typePasswordInput(usernameInput);
+    this.saveStatus(response);
+    if (this.results.error || !passwordInput) {
       return;
     }
-
-    // Type the password
-    log.debug('Entering password and logging in...');
-    await passwordInput.type(login.password, {
-      noWaitAfter: true,
-      timeout: this.timeBudget.get(),
-    });
 
     // Submit
     await this.#submitForm(passwordInput);
-
     await this.saveStatus(response);
     if (this.results.error) {
       return;
@@ -85,58 +72,123 @@ export class LoginTask extends Task<LoginTaskParams> {
     // we get the cookie for the requested domain
     // this is not ideal for some SSO, returning valid cookies but missing some of them
     this.results.cookies = await this.page.ref?.context().cookies([url.href]);
+
+    if (this.results.cookies.length <= 0) {
+      this.results.error = 'no_cookies';
+      return;
+    }
+
     const body = await this.page.renderBody();
     this.results.body = body;
     this.setMetric('serialize');
   }
 
   /**
-   * Get password input.
+   * Check if there is an usable form in the page.
    */
-  async #getPasswordInput(
-    textInput: ElementHandle<HTMLElement | SVGElement>
-  ): Promise<ElementHandle<HTMLElement | SVGElement> | null | void> {
-    const log = this.log;
-    const inputSel = 'input[type=password]:not([aria-hidden="true"])';
-
-    const passwordInputLoc = this.page!.ref?.locator(inputSel);
-    if (passwordInputLoc && (await passwordInputLoc.count()) > 0) {
-      return await passwordInputLoc.elementHandle();
+  async #checkForm(): Promise<Locator | void> {
+    const textInputLoc = this.page?.ref?.locator(
+      'input[type=text], input[type=email]'
+    );
+    if (!textInputLoc || (await textInputLoc.count()) <= 0) {
+      this.results.error = 'field_not_found';
+      this.results.rawError = new Error('input[type=text], input[type=email]');
+      return;
     }
 
-    // it can be that we are in a "two step form"
-    log.info('No password input found: validating username...');
+    return textInputLoc;
+  }
+
+  /**
+   * Get username input and type the value in it.
+   */
+  async #typeUsername(
+    usernameInputLoc?: Locator
+  ): Promise<ElementHandle<HTMLElement | SVGElement> | null | undefined> {
+    const log = this.log;
+    const { login } = this.params;
+
     try {
-      // We submit the form
-      await textInput!.press('Enter', {
+      log.debug('Current URL', { pageUrl: this.page?.ref?.url() });
+      log.info('Entering username...', { userName: login.username });
+
+      const usernameInput = await usernameInputLoc?.elementHandle({
+        timeout: 500,
+      });
+      await usernameInput?.type(login.username, {
         noWaitAfter: true,
         timeout: this.timeBudget.limit(1000),
       });
+
+      return usernameInput;
+    } finally {
       this.timeBudget.consume();
+    }
+  }
 
-      // And wait for a new input to be there maybe
-      // page!.waitForNavigation() doesn't work with Okta for example, it's JS based
-      await this.page!.ref?.waitForSelector(inputSel, {
-        timeout: this.timeBudget.limit(1000),
-      });
-      this.timeBudget.consume();
+  /**
+   * Get password input.
+   */
+  async #typePasswordInput(
+    textInput: ElementHandle<HTMLElement | SVGElement>
+  ): Promise<ElementHandle<HTMLElement | SVGElement> | null | void> {
+    const { login } = this.params;
+    const log = this.log;
+    const inputSel = 'input[type=password]:not([aria-hidden="true"])';
 
-      log.debug('Current URL', { pageUrl: this.page!.ref?.url() });
+    try {
+      // Find the input
+      let passwordInputLoc = this.page!.ref?.locator(inputSel);
 
-      const loc = this.page!.ref?.locator(inputSel);
-      if (loc && (await loc.count()) > 0) {
-        return await loc.elementHandle();
+      if (!passwordInputLoc || (await passwordInputLoc.count()) <= 0) {
+        // It can be that we are in a "two step form"
+        log.info('No password input found: validating username...');
+
+        // Submit the form to see if the second step appears
+        await textInput.press('Enter', {
+          noWaitAfter: true,
+          timeout: this.timeBudget.limit(1000),
+        });
+        this.timeBudget.consume();
+
+        // And wait for a new input to be there maybe
+        // page!.waitForNavigation() doesn't work with Okta for example, it's JS based
+        await this.page!.ref?.waitForSelector(inputSel, {
+          timeout: this.timeBudget.limit(1000),
+        });
+        this.timeBudget.consume();
+
+        log.debug('Current URL', { pageUrl: this.page!.ref?.url() });
+
+        passwordInputLoc = this.page!.ref?.locator(inputSel);
       }
+
+      if (!passwordInputLoc || (await passwordInputLoc.count()) <= 0) {
+        // Can't definitely not find a password input
+        this.results.error = 'field_not_found';
+        this.results.rawError = new Error(inputSel);
+        return;
+      }
+
+      // Type the password
+      log.debug('Entering password and logging in...');
+      await passwordInputLoc.type(login.password, {
+        noWaitAfter: true,
+        timeout: this.timeBudget.get(),
+      });
+
+      return passwordInputLoc?.elementHandle();
     } catch (err: any) {
+      await this.page?.close();
+
       log.info('No password input on the page', {
         err: err.message,
         pageUrl: this.page!.ref?.url(),
       });
 
       this.results.error = cleanErrorMessage(err);
+      this.results.rawError = err;
     }
-
-    return null;
   }
 
   /**
@@ -195,6 +247,7 @@ export class LoginTask extends Task<LoginTaskParams> {
       }
     } catch (err: any) {
       this.results.error = cleanErrorMessage(err);
+      this.results.rawError = err;
       report(new Error('Error while spec'), {
         err: err.message,
         pageUrl: this.page!.ref?.url(),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,6 +10,7 @@ export type HandledError =
   | 'fetch_timeout'
   | 'field_not_found'
   | 'forbidden_by_website'
+  | 'no_cookies'
   | 'no_response_after_login'
   | 'page_closed_too_soon'
   | 'page_crashed'


### PR DESCRIPTION
- Catch more errors during login
- Implement the same RetryableErrors strategy as the /render
- Split the code readability