### PR TITLE
fix(cookies): output from original url and resolved url

### DIFF
--- a/src/lib/tasks/Login.ts
+++ b/src/lib/tasks/Login.ts
@@ -71,7 +71,9 @@ export class LoginTask extends Task<LoginTaskParams> {
     this.results.resolvedUrl = this.page.ref.url();
     // we get the cookie for the requested domain
     // this is not ideal for some SSO, returning valid cookies but missing some of them
-    this.results.cookies = await this.page.ref?.context().cookies([url.href]);
+    this.results.cookies = await this.page.ref
+      ?.context()
+      .cookies([url.href, this.results.resolvedUrl]);
 
     if (this.results.cookies.length <= 0) {
       this.results.error = 'no_cookies';


### PR DESCRIPTION
Return cookie for the original URL that started the login and the resolved URL, because login can redirect to multiple domains.
We could output all the cookies but for the moment I'm not confident with that since names are not unique.