### PR TITLE
fix(api): catch all at the end + 404 + / in prod

### DIFF
--- a/src/api/@types/getRoot.ts
+++ b/src/api/@types/getRoot.ts
@@ -1,0 +1,3 @@
+export interface GetRoot {
+  version: string;
+}

--- a/src/api/routes/root.ts
+++ b/src/api/routes/root.ts
@@ -1,0 +1,10 @@
+import type express from 'express';
+
+import type { GetRoot } from 'api/@types/GetRoot';
+
+export function root(
+  req: express.Request,
+  res: express.Response<GetRoot>
+): void {
+  res.status(200).json({ version: process.env.VERSION || 'dev' });
+}


### PR DESCRIPTION
- Catch all errors should be after all endpoints
- There was no 404 handler
- There was no `/` in prod