### PR TITLE
fix(docker): build image locally and on CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
       dry_run:
         required: true
         type: boolean
-        default: 'true'
+        default: true
         description: 'DryRun?'
 
 env:

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -8,7 +8,7 @@ on:
       dry_run:
         required: true
         type: boolean
-        default: 'true'
+        default: true
         description: 'DryRun?'
 
 env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ------------------
 # Build playwright
 # ------------------
-FROM ubuntu:focal as base
+FROM ubuntu:jammy as base
 
 # For tzdata
 ARG DEBIAN_FRONTEND=noninteractive
@@ -25,9 +25,10 @@ RUN apt-get update && \
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
 # Browsers will be downloaded in `/ms-playwright`.
+# !!! MAKE SURE THE PLAYWRIGHT VERSION MATCHES THE ONE IN package.json
 RUN mkdir /ms-playwright \
-  && npx playwright install chromium \
-  && npx playwright install-deps chromium \
+  && npx playwright@1.26.1 install chromium \
+  && npx playwright@1.26.1 install-deps chromium \
   # Clean cache
   && rm -rf /var/lib/apt/lists/* \
   && chmod -R 777 /ms-playwright
@@ -36,7 +37,7 @@ RUN mkdir /ms-playwright \
 # ------------------
 # package.json cache
 # ------------------
-FROM apteno/alpine-jq:2022-03-27 AS deps
+FROM apteno/alpine-jq:2022-09-25 AS deps
 
 # To prevent cache invalidation from changes in fields other than dependencies
 COPY package.json /tmp

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,11 +9,15 @@ echo ""
 
 # Build renderscript
 
+# To run locally on your mac m1, you need to change platform to linux/arm64/v8
+# For deploy, it should be linux/amd64
 docker buildx build \
-  --platform linux/arm64/v8,linux/amd64 \
+  --platform linux/amd64 \
   --progress plain \
   -t algolia/renderscript \
   -t "algolia/renderscript:${current}" \
   -t "algolia/renderscript:${hash}" \
+  -t "algolia/renderscript:latest" \
   --build-arg "VERSION=${current}" \
+  --load \
   .

--- a/scripts/test_image.sh
+++ b/scripts/test_image.sh
@@ -5,11 +5,16 @@ set -e
 hash=$1 # the last commit change because of semantic-release
 docker run -d --name renderscript_test -p 3000:3000 algolia/renderscript:$hash
 
-echo "waiting for docker"
-sleepSec=20
-sleep $sleepSec
-
-echo "slept for ${sleepSec}s"
+ATTEMPTS=10
+until $(curl -o /dev/null -s -f http://localhost:3000/ready); do
+  echo "waiting for docker..."
+  sleep 1
+  ((ATTEMPTS=ATTEMPTS-1))
+  if [[ $ATTEMPTS -eq "0" ]]; then
+    echo "Timed out, check the logs of renderscript_test container"
+    exit 1
+  fi
+done
 
 logs=$(docker logs renderscript_test 2>&1)
 echo $logs


### PR DESCRIPTION
the chrome version (in /ms-playwright/chrome-XXXX) is linked with the playwright version (according to this [comment](https://github.com/microsoft/playwright-python/issues/168#issuecomment-673956499)), but in the package.json it's fixed and with npx in the Dockerfile it's the latest, so there is a mismatch.

We need to be careful when upgrading playwright version.

Some other changes:
- fix github action syntax
- update images in Dockerfile
- add latest tag
- use wait loop to make the test image faster