### PR TITLE
fix: remove browser flag: --disk-cache-dir=/dev/null

### DIFF
--- a/src/lib/browser/constants.ts
+++ b/src/lib/browser/constants.ts
@@ -39,7 +39,6 @@ export const flags = [
   "--proxy-server='direct://'",
   '--proxy-bypass-list=*',
   // Disable cache
-  '--disk-cache-dir=/dev/null',
   '--media-cache-size=1',
   '--disk-cache-size=1',
   // Disable useless UI features


### PR DESCRIPTION
We have noticed that some pages rendering is flaky.
Using the script below, I've been able to reproduce the behaviour locally, almost consistently (still not 100% of the time).
I've then played with the flags, and I've identified that the culprit seems to be the `--disk-cache-dir=/dev/null`

The needed things to reproduce are:
- Have this flag to redirect the cache to `/dev/null`
- Reuse the same context to create new pages.
  - When I update the script to create a new context at each loop, it works. I guess it doesn't try to read the cache at all in that case

As you will see in [the TaskManager code](https://github.com/algolia/renderscript/blob/master/src/lib/TasksManager.ts#L117), we normally don't reuse the context, so I can't be sure this is the proper fix. But I may miss something, so it worth trying as it's my only lead for now.

### Repro script

You can find the URL and the resulting screenshot on the CR-2155 ticket.

```js
const { chromium } = require('playwright');

(async () => {
  const browser = await chromium.launch({
    args: [
      // Disable cache
      '--disk-cache-dir=/dev/null',
      // '--media-cache-size=1',
      // '--disk-cache-size=1',
    ],
  });

  const ctx = await browser.newContext();

  let success;
  let attempt = 1;
  do {
    console.log(`attempt ${attempt}...`);
    const page = await ctx.newPage();
    await page.goto(
      'http://example.com',
      { waitUntil: 'networkidle' }
    );
    const element = page.locator('h1');
    success = (await element.count()) > 0;
    await page.screenshot({ path: 'screenshot.png' });
    await page.close();
    ++attempt;
  } while (success && attempt <= 10);

  await browser.close();
})();

```