### PR TITLE
fix(login): manually wait for pending requests

### DIFF
--- a/src/helpers/waitForPendingRequests.ts
+++ b/src/helpers/waitForPendingRequests.ts
@@ -1,0 +1,25 @@
+import { setTimeout } from 'timers/promises';
+
+import { log } from 'helpers/logger';
+import type { BrowserPage } from 'lib/browser/Page';
+
+// waitForNavigation({ waitUntil: 'networkidle' }) or waitForLoadState('networkidle')
+// can be flaky and return too soon:
+// https://github.com/microsoft/playwright/issues/4664#issuecomment-742691215
+// https://github.com/microsoft/playwright/issues/2515#issuecomment-724163391
+// This helper permits to manually wait, if the page still has pending requests.
+export async function waitForPendingRequests(
+  page: BrowserPage,
+  timeout: number
+): Promise<void> {
+  const startTime = Date.now();
+  while (page.pendingRequests > 0 && Date.now() - startTime < timeout) {
+    log.debug(
+      { pageUrl: page.ref?.url() },
+      `Waiting for ${page.pendingRequests} requests to complete... Wait time:${
+        Date.now() - startTime
+      }, timeout: ${timeout}`
+    );
+    await setTimeout(1000);
+  }
+}

--- a/src/lib/tasks/Render.ts
+++ b/src/lib/tasks/Render.ts
@@ -53,7 +53,7 @@ export class RenderTask extends Task<RenderTaskParams> {
     // --- At this point we have just the DOM, but we want to do some checks
     await this.saveMetrics();
 
-    // In case of redirection, initialResponse is prefered since response is probably now incorrect
+    // In case of redirection, initialResponse is preferred since response is probably now incorrect
     await this.saveStatus(this.page.initialResponse || response);
 
     if (this.page.redirection) {


### PR DESCRIPTION
Similarly to #654, we to noticed that the login feature could fail because we return too soon, while all requests have not finished yet.

This PR adds the exact same manual check (refactored into a dedicated helper)