### PR TITLE
fix: test_image.sh

### DIFF
--- a/scripts/test_image.sh
+++ b/scripts/test_image.sh
@@ -19,7 +19,7 @@ done
 logs=$(docker logs renderscript_test 2>&1)
 echo $logs
 
-if echo $logs | grep -q '"svc":"brws","msg":"Browser ready"'; then
+if echo $logs | grep -q '"svc":"brws","msg":"Ready"'; then
   echo "Browser ready"
 else
   echo "Browser not ready"

--- a/scripts/test_image.sh
+++ b/scripts/test_image.sh
@@ -19,6 +19,13 @@ done
 logs=$(docker logs renderscript_test 2>&1)
 echo $logs
 
+if echo $logs | grep -q '"svc":"brws","msg":"Browser ready"'; then
+  echo "Browser ready"
+else
+  echo "Browser not ready"
+  exit 1
+fi
+
 curl --silent --request POST \
   --url http://localhost:3000/render \
   --header 'Content-Type: application/json' \
@@ -34,17 +41,12 @@ curl --silent --request POST \
 logs=$(docker logs renderscript_test 2>&1)
 echo $logs
 
-launched=$(echo $logs | grep '"svc":"brws","msg":"Ready"')
-if [ -z "$launched" ]; then
-  echo "Not ready"
-  exit 1
-fi
-
-rendered=$(echo $logs | grep '"msg":"Done","data":')
-if [ -z "$rendered" ]; then
+if echo $logs | grep -q '"msg":"Done","data":'; then
+  echo "Rendered"
+else
   echo "Not rendered"
   exit 1
 fi
 
-echo "Ready"
+echo "Image OK"
 docker stop renderscript_test && docker rm renderscript_test

--- a/src/lib/browser/Browser.ts
+++ b/src/lib/browser/Browser.ts
@@ -76,7 +76,7 @@ export class Browser {
     });
 
     this.#ready = true;
-    log.info('Browser ready', { id: this.#id, browser: this.#engine });
+    log.info('Ready', { id: this.#id, browser: this.#engine });
   }
 
   async stop(): Promise<void> {


### PR DESCRIPTION
The build of the image is failing because I've updated a log it was relying on.

The bad thing is that it is currently failing with a simple: `Error: Process completed with exit code 1.` (c.f. https://github.com/algolia/renderscript/actions/runs/3639334496/jobs/6152011129)

This is because when grep fails, it actually exits 1 by default, before displaying any error message.

Changes:
- Revert the log message
- Fix the grep check using an `if` as described here: https://stackoverflow.com/a/56170435/1326281
- Move the browser check before trying an actual render

How to test:
- `docker build . -t algolia/renderscript`
- `./scripts/test_image.sh latest`