### PR TITLE
fix(build): align playwright version

### DIFF
--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -32,6 +32,7 @@ jobs:
         shell: bash
         run: |
           echo "::set-output name=RENDERSCRIPT_VERSION::$(node -e 'console.log(require("./package.json").version)')"
+          echo "::set-output name=PLAYWRIGHT_VERSION::$(node -e 'console.log(require("./package.json").dependencies.playwright)')"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -62,6 +63,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             VERSION=${{ steps.env_var.outputs.RENDERSCRIPT_VERSION }}
+            PLAYWRIGHT_VERSION=${{ steps.env_var.outputs.PLAYWRIGHT_VERSION }}
 
       - name: Test Image
         run: ./scripts/test_image.sh ${{ env.COMMIT_SHA }}
@@ -82,3 +84,4 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             VERSION=${{ steps.env_var.outputs.RENDERSCRIPT_VERSION }}
+            PLAYWRIGHT_VERSION=${{ steps.env_var.outputs.PLAYWRIGHT_VERSION }}

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -31,8 +31,8 @@ jobs:
         id: env_var
         shell: bash
         run: |
-          echo "::set-output name=RENDERSCRIPT_VERSION::$(node -e 'console.log(require("./package.json").version)')"
-          echo "::set-output name=PLAYWRIGHT_VERSION::$(node -e 'console.log(require("./package.json").dependencies.playwright)')"
+          echo "RENDERSCRIPT_VERSION=$(node -e 'console.log(require("./package.json").version)')" >> $GITHUB_OUTPUT
+          echo "PLAYWRIGHT_VERSION=$(node -e 'console.log(require("./package.json").dependencies.playwright)')" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG TZ=America/Los_Angeles
 RUN apt-get update && \
   # Install node16
   apt-get install -y curl wget && \
-  curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
+  curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
   apt-get install -y nodejs && \
   # Feature-parity with node.js base images.
   apt-get install -y --no-install-recommends git openssh-client && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ ENV PLAYWRIGHT_VERSION ${PLAYWRIGHT_VERSION}
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
 # Browsers will be downloaded in `/ms-playwright`.
-# !!! MAKE SURE THE PLAYWRIGHT VERSION MATCHES THE ONE IN package.json
 RUN mkdir /ms-playwright \
   && PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=true npm install -g playwright@$PLAYWRIGHT_VERSION \
   && npx playwright install --with-deps chromium \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,14 @@ RUN apt-get update && \
   adduser pwuser
 
 # === BAKE BROWSERS INTO IMAGE ===
+ARG PLAYWRIGHT_VERSION
+ENV PLAYWRIGHT_VERSION ${PLAYWRIGHT_VERSION}
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
 # Browsers will be downloaded in `/ms-playwright`.
 # !!! MAKE SURE THE PLAYWRIGHT VERSION MATCHES THE ONE IN package.json
 RUN mkdir /ms-playwright \
-  && PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=true npm install -g playwright@1.29.2 \
+  && PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=true npm install -g playwright@$PLAYWRIGHT_VERSION \
   && npx playwright install --with-deps chromium \
   && npx playwright install --with-deps firefox \
   # Clean cache

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,7 +4,8 @@ set -ex
 
 hash=$(git rev-parse HEAD)
 current=$(node -e "console.log(require('./package.json').version)")
-echo "Releasing: $current"
+playwright_version=$(jq -r '.dependencies.playwright' < package.json)
+echo "Releasing: $current ; Playwright version: $playwright_version"
 echo ""
 
 # Build renderscript
@@ -19,5 +20,6 @@ docker buildx build \
   -t "algolia/renderscript:${hash}" \
   -t "algolia/renderscript:latest" \
   --build-arg "VERSION=${current}" \
+  --build-arg "PLAYWRIGHT_VERSION=${playwright_version}" \
   --load \
   .

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,7 +4,7 @@ set -ex
 
 hash=$(git rev-parse HEAD)
 current=$(node -e "console.log(require('./package.json').version)")
-playwright_version=$(jq -r '.dependencies.playwright' < package.json)
+playwright_version=$(node -e 'console.log(require("./package.json").dependencies.playwright)')
 echo "Releasing: $current ; Playwright version: $playwright_version"
 echo ""
 

--- a/scripts/test_image.sh
+++ b/scripts/test_image.sh
@@ -9,9 +9,10 @@ ATTEMPTS=10
 until $(curl -o /dev/null -s -f http://localhost:3000/ready); do
   echo "waiting for docker..."
   sleep 1
-  ((ATTEMPTS=ATTEMPTS-1))
+  ATTEMPTS=$((ATTEMPTS-1))
   if [[ $ATTEMPTS -eq "0" ]]; then
-    echo "Timed out, check the logs of renderscript_test container"
+    echo "Timed out, check the logs of renderscript_test container:"
+    docker logs renderscript_test -n 50
     exit 1
   fi
 done


### PR DESCRIPTION
The release [failed](https://github.com/algolia/renderscript/actions/runs/3937825768) this morning because the version of Playwright set in the `Dockerfile` was not aligned with the one in the `package.json`

This also showed that the `test_image.sh` script was buggy, and exiting too early. Indeed, I've learned that `((...))` in bash returns with an exit code of 1 if the expression is zero: https://unix.stackexchange.com/a/597023/161025
```sh
$ ((TEST=1))
$ echo $?
0

$ ((TEST=0))
echo $?
1
```

Lastly, we've been seeing warning messages during the build: The `set-output` command is deprecated and will be disabled soon. This is due to https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/, and it's a good occasion to fix them.

### Changes

- Fix `test_image.sh` to show the docker image logs in case of failure
- Add the `PLAYWRIGHT_VERSION` env var to the Dockerfile, and inject it from the build script or the GitHub Action
- Update deprecated `set-output` command by following https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

---

CRAW-2474

[CRAW-2474]: https://algolia.atlassian.net/browse/CRAW-2474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ