### PR TITLE
fix: better error reporting

### DIFF
--- a/src/api/routes/render.ts
+++ b/src/api/routes/render.ts
@@ -72,7 +72,7 @@ export async function render(
     res.status(500).json({
       error: err.message,
     });
-    report(err, { type: 'render', url: rawUrl });
+    report(err, { type: 'render', url: rawUrl, browser });
   }
 }
 
@@ -126,6 +126,6 @@ export async function renderJSON(
     });
   } catch (err: any) {
     res.status(500).json({ error: err.message });
-    report(err, { type: 'renderJSON', url: rawUrl });
+    report(err, { type: 'renderJSON', url: rawUrl, browser });
   }
 }

--- a/src/lib/TasksManager.ts
+++ b/src/lib/TasksManager.ts
@@ -184,8 +184,8 @@ export class TasksManager {
       if (!(err instanceof ErrorIsHandledError)) {
         task.results.error = task.results.error || cleanErrorMessage(err);
         task.results.rawError = err;
+        report(err, { url });
       }
-      report(err, { url });
       /* eslint-enable no-param-reassign */
     }
 

--- a/src/lib/browser/Browser.ts
+++ b/src/lib/browser/Browser.ts
@@ -15,6 +15,7 @@ import { flags, HEIGHT, WIDTH } from './constants';
 const log = mainLog.child({ svc: 'brws' });
 
 export type BrowserEngine = 'chromium' | 'firefox';
+export const DEFAULT_ENGINE: BrowserEngine = 'chromium';
 
 export class Browser {
   #id;

--- a/src/lib/browser/Page.ts
+++ b/src/lib/browser/Page.ts
@@ -281,7 +281,7 @@ export class BrowserPage {
           throw err;
         }
       }
-      report(err, { url: this.ref?.url() });
+      report(err, { url: this.ref?.url(), browser: this.#engine });
     }
     return null;
   }
@@ -468,7 +468,12 @@ export class BrowserPage {
           return;
         }
 
-        report(err, { context: 'onRequest', url: url.href, with: reqUrl });
+        report(err, {
+          context: 'onRequest',
+          url: url.href,
+          with: reqUrl,
+          browser: this.#engine,
+        });
       }
     };
   }

--- a/src/lib/tasks/Task.ts
+++ b/src/lib/tasks/Task.ts
@@ -106,7 +106,7 @@ export abstract class Task<TTaskType extends TaskBaseParams = TaskBaseParams> {
     context.setDefaultTimeout(WAIT_TIME.min);
     context.setDefaultNavigationTimeout(WAIT_TIME.max);
 
-    const page = new BrowserPage(context);
+    const page = new BrowserPage(context, this.params.browser);
     this.page = page;
     this.#context = context;
 

--- a/src/lib/tasks/Task.ts
+++ b/src/lib/tasks/Task.ts
@@ -179,6 +179,9 @@ export abstract class Task<TTaskType extends TaskBaseParams = TaskBaseParams> {
   throwHandledError(res: ErrorReturn): void {
     this.results.error = res.error;
     this.results.rawError = res.rawError || null;
+    stats.increment('renderscript.task.handlederror', {
+      error: res.error || 'no_error',
+    });
     throw new ErrorIsHandledError();
   }
 


### PR DESCRIPTION
DI-1233

We are seeing some pages failing to render with a [`body_serialisation_failed` error](https://github.com/algolia/renderscript/blob/master/src/lib/tasks/Render.ts#L115).
To understand better what happen:

- Report rendering errors
- Track the rendering time

Also:
- Stop reporting handled errors to not flood the reporting, only count them