### PR TITLE
fix: increase timeout of renderBody and add more logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "yarn clean && yarn ttsc",
-    "ci:start": "ALLOW_LOCALHOST=true yarn start",
+    "ci:start": "NODE_ENV=test ALLOW_LOCALHOST=true yarn start",
     "clean": "rm -rf dist/",
     "dev": "nodemon",
     "dev:run": "yarn build && NODE_ENV=development node -r dotenv/config dist/index.js",

--- a/src/lib/browser/Page.ts
+++ b/src/lib/browser/Page.ts
@@ -266,6 +266,7 @@ export class BrowserPage {
     { silent }: { silent: boolean } = { silent: false }
   ): Promise<string | null> {
     try {
+      console.log(process.env.NODE_ENV);
       return await promiseWithTimeout(
         (async (): Promise<string | null> => {
           const startUsage = cpuUsage();
@@ -284,7 +285,7 @@ export class BrowserPage {
           }
           return content || null;
         })(),
-        20000 // this is the most important part so we try hard
+        process.env.NODE_ENV !== 'production' ? 10000 : 20000 // this is the most important part so we try hard
       );
     } catch (err: any) {
       if (!(err instanceof PromiseWithTimeoutError)) {

--- a/src/lib/browser/Page.ts
+++ b/src/lib/browser/Page.ts
@@ -1,4 +1,4 @@
-import { memoryUsage } from 'node:process';
+import { cpuUsage, memoryUsage } from 'node:process';
 
 import type { BrowserContext, Page, Route, Response } from 'playwright';
 
@@ -268,6 +268,7 @@ export class BrowserPage {
     try {
       return await promiseWithTimeout(
         (async (): Promise<string | null> => {
+          const startUsage = cpuUsage();
           const start = Date.now();
           const content = await this.#ref?.content();
           const renderTime = Date.now() - start;
@@ -279,6 +280,7 @@ export class BrowserPage {
               url: this.ref?.url(),
             });
             log.info('Memory usage:', memoryUsage());
+            log.info('CPU used since rendering started:', cpuUsage(startUsage));
           }
           return content || null;
         })(),


### PR DESCRIPTION
Some pages are taking a lot of time to dump the HTML.
I think we need to increase the CPU allocation, but let's also increase the timeout here, and add more reporting about the resources usage.