### PR TITLE
fix: catch browser crash on start

### DIFF
--- a/src/lib/browser/Page.ts
+++ b/src/lib/browser/Page.ts
@@ -281,7 +281,11 @@ export class BrowserPage {
           throw err;
         }
       }
-      report(err, { url: this.ref?.url(), browser: this.#engine });
+      report(err, {
+        url: this.ref?.url(),
+        browser: this.#engine,
+        action: 'renderBody',
+      });
     }
     return null;
   }


### PR DESCRIPTION
Firefox gets `'disconnected'` regularly, when that happen, we call `this.create();` to start another instance. But it turns out that it can throw an error when trying to launch it, which makes the whole process crash:
```
"browserType.launch: Browser.enable): Browser closed.
==================== Browser output: ====================
<launching> /ms-playwright/firefox-1391/firefox/firefox -no-remote -headless -profile /tmp/playwright_firefoxdev_profile-LKs7fU -juggler-pipe --no-sandbox --disable-setuid-sandbox --no-zygote --disable-gpu --proxy-server='direct://' --proxy-bypass-list=* --disk-cache-dir=/dev/null --media-cache-size=1 --disk-cache-size=1 --disable-extensions --disable-features=Translate --disable-infobars --disable-notifications --disable-translate --no-default-browser-check --no-first-run --noerrdialogs --disable-background-timer-throttling --disable-password-generation --disable-prompt-on-repos --disable-save-password-bubble --disable-single-click-autofill --disable-restore-session-state --disable-translate --disable-new-profile-management --disable-new-avatar-menu --disable-infobars --disable-device-discovery-notifications --disable-client-side-phishing-detection --disable-notifications --disable-component-extensions-with-background-pages --disable-dev-shm-usage --disable-web-resources --safebrowsing-disable-auto-update --safebrowsing-disable-download-protection --disable-client-side-phishing-detection --disable-component-update --disable-default-apps --disable-breakpad --disable-crash-reporter -silent
<launched> pid=1785
[pid=1785][err] *** You are running in headless mode.
[pid=1785][out] console.warn: services.settings: Ignoring preference override of remote settings server
[pid=1785][out] console.warn: services.settings: Allow by setting MOZ_REMOTE_SETTINGS_DEVTOOLS=1 in the environment
[pid=1785] <process did exit: exitCode=null, signal=SIGKILL>
[pid=1785] starting temporary directories cleanup
=========================== logs ===========================
<launching> /ms-playwright/firefox-1391/firefox/firefox -no-remote -headless -profile /tmp/playwright_firefoxdev_profile-LKs7fU -juggler-pipe --no-sandbox --disable-setuid-sandbox --no-zygote --disable-gpu --proxy-server='direct://' --proxy-bypass-list=* --disk-cache-dir=/dev/null --media-cache-size=1 --disk-cache-size=1 --disable-extensions --disable-features=Translate --disable-infobars --disable-notifications --disable-translate --no-default-browser-check --no-first-run --noerrdialogs --disable-background-timer-throttling --disable-password-generation --disable-prompt-on-repos --disable-save-password-bubble --disable-single-click-autofill --disable-restore-session-state --disable-translate --disable-new-profile-management --disable-new-avatar-menu --disable-infobars --disable-device-discovery-notifications --disable-client-side-phishing-detection --disable-notifications --disable-component-extensions-with-background-pages --disable-dev-shm-usage --disable-web-resources --safebrowsing-disable-auto-update --safebrowsing-disable-download-protection --disable-client-side-phishing-detection --disable-component-update --disable-default-apps --disable-breakpad --disable-crash-reporter -silent
<launched> pid=1785
[pid=1785][err] *** You are running in headless mode.
[pid=1785][out] console.warn: services.settings: Ignoring preference override of remote settings server
[pid=1785][out] console.warn: services.settings: Allow by setting MOZ_REMOTE_SETTINGS_DEVTOOLS=1 in the environment
[pid=1785] <process did exit: exitCode=null, signal=SIGKILL>
[pid=1785] starting temporary directories cleanup
============================================================"
```

## Changes

- Add a catch to avoid the process to crash