### PR TITLE
fix: upgrade playwright and deps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     name: Lint
-    env:
-      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 'false'
     steps:
       - uses: actions/checkout@v4
 
@@ -28,7 +26,7 @@ jobs:
       - run: yarn install --frozen-lockfile
 
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium firefox
+        run: yarn playwright install
 
       - name: Run Linter
         run: yarn lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     name: Lint
-    env:
-      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 'false'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,8 +3,8 @@ name: Renderscript
 on:
   push:
     branches:
-      - "master"
-      - "renovate/**"
+      - 'master'
+      - 'renovate/**'
   pull_request:
 
 env:
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Lint
     env:
-      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "true"
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 'false'
     steps:
       - uses: actions/checkout@v4
 
@@ -25,7 +25,10 @@ jobs:
           node-version-file: .nvmrc
           cache: yarn
 
-      - run: yarn install
+      - run: yarn install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium firefox
 
       - name: Run Linter
         run: yarn lint
@@ -54,4 +57,3 @@ jobs:
 
       - name: Run test
         run: yarn test
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     name: Lint
+    env:
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 'false'
     steps:
       - uses: actions/checkout@v4
 
@@ -24,9 +26,6 @@ jobs:
           cache: yarn
 
       - run: yarn install --frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: yarn playwright install
 
       - name: Run Linter
         run: yarn lint
@@ -44,7 +43,10 @@ jobs:
           node-version-file: .nvmrc
           cache: yarn
 
-      - run: yarn install
+      - run: yarn install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: yarn playwright install
 
       - name: Build
         run: yarn build

--- a/package.json
+++ b/package.json
@@ -79,11 +79,11 @@
     "body-parser": "1.20.2",
     "cookie-parser": "1.4.6",
     "csurf": "1.11.0",
-    "express": "4.18.2",
+    "express": "4.19.2",
     "hot-shots": "10.0.0",
     "pino": "8.16.2",
-    "playwright": "1.37.1",
-    "undici": "5.27.2",
+    "playwright": "1.44.1",
+    "undici": "5.28.4",
     "uuid": "9.0.1"
   },
   "resolutions": {

--- a/src/lib/browser/constants.ts
+++ b/src/lib/browser/constants.ts
@@ -39,7 +39,7 @@ export const flags = [
   "--proxy-server='direct://'",
   '--proxy-bypass-list=*',
   // Disable cache
-  '--disk-cache-dir=/dev/null',
+  // '--disk-cache-dir=/dev/null',
   '--media-cache-size=1',
   '--disk-cache-size=1',
   // Disable useless UI features
@@ -52,6 +52,7 @@ export const flags = [
   '--no-first-run', // screen on very first run
   '--noerrdialogs',
   '--disable-background-timer-throttling',
+  '--disable-backgrounding-occluded-windows',
   '--disable-password-generation',
   '--disable-prompt-on-repos',
   '--disable-save-password-bubble',
@@ -68,6 +69,11 @@ export const flags = [
   // Disable dev-shm
   // See https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#tips
   '--disable-dev-shm-usage',
+
+  '--enable-automation',
+  '--disable-print-preview',
+  // https://github.com/cypress-io/cypress/issues/5132
+  '--disable-ipc-flooding-protection',
 
   // Taken from https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/browsers/chrome.ts
   // "--disable-background-networking"

--- a/src/lib/tasks/Login.ts
+++ b/src/lib/tasks/Login.ts
@@ -115,7 +115,8 @@ export class LoginTask extends Task<LoginTaskParams> {
       const usernameInput = await usernameInputLoc.elementHandle({
         timeout: 500,
       });
-      await usernameInput?.type(login.username, {
+      // https://playwright.dev/docs/release-notes#version-138
+      await usernameInput?.fill(login.username, {
         noWaitAfter: true,
         timeout: this.timeBudget.getRange(2000, 3000),
       });
@@ -144,7 +145,7 @@ export class LoginTask extends Task<LoginTaskParams> {
       const passwordInputLoc = await getInput(page, passwordSel);
       if (!('error' in passwordInputLoc)) {
         this.log.info('Entering password...');
-        await passwordInputLoc.type(login.password, {
+        await passwordInputLoc.fill(login.password, {
           noWaitAfter: true,
           timeout: this.timeBudget.getRange(2000, 3000),
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -56,19 +56,19 @@ __metadata:
     eslint-plugin-node: "npm:11.1.0"
     eslint-plugin-prettier: "npm:5.0.1"
     eslint-plugin-promise: "npm:6.1.1"
-    express: "npm:4.18.2"
+    express: "npm:4.19.2"
     hot-shots: "npm:10.0.0"
     jest: "npm:29.7.0"
     nodemon: "npm:3.0.1"
     pino: "npm:8.16.2"
     pino-pretty: "npm:10.2.3"
-    playwright: "npm:1.37.1"
+    playwright: "npm:1.44.1"
     prettier: "npm:3.1.0"
     semantic-release: "npm:22.0.8"
     ts-jest: "npm:29.1.1"
     ts-node: "npm:10.9.1"
     typescript: "npm:5.2.2"
-    undici: "npm:5.27.2"
+    undici: "npm:5.28.4"
     uuid: "npm:9.0.1"
   languageName: unknown
   linkType: soft
@@ -2644,26 +2644,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"body-parser@npm:1.20.1":
-  version: 1.20.1
-  resolution: "body-parser@npm:1.20.1"
-  dependencies:
-    bytes: "npm:3.1.2"
-    content-type: "npm:~1.0.4"
-    debug: "npm:2.6.9"
-    depd: "npm:2.0.0"
-    destroy: "npm:1.2.0"
-    http-errors: "npm:2.0.0"
-    iconv-lite: "npm:0.4.24"
-    on-finished: "npm:2.4.1"
-    qs: "npm:6.11.0"
-    raw-body: "npm:2.5.1"
-    type-is: "npm:~1.6.18"
-    unpipe: "npm:1.0.0"
-  checksum: 5f8d128022a2fb8b6e7990d30878a0182f300b70e46b3f9d358a9433ad6275f0de46add6d63206da3637c01c3b38b6111a7480f7e7ac2e9f7b989f6133fe5510
-  languageName: node
-  linkType: hard
-
 "body-parser@npm:1.20.2":
   version: 1.20.2
   resolution: "body-parser@npm:1.20.2"
@@ -3269,10 +3249,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:0.5.0":
-  version: 0.5.0
-  resolution: "cookie@npm:0.5.0"
-  checksum: aae7911ddc5f444a9025fbd979ad1b5d60191011339bce48e555cb83343d0f98b865ff5c4d71fecdfb8555a5cafdc65632f6fce172f32aaf6936830a883a0380
+"cookie@npm:0.6.0":
+  version: 0.6.0
+  resolution: "cookie@npm:0.6.0"
+  checksum: c1f8f2ea7d443b9331680598b0ae4e6af18a618c37606d1bbdc75bec8361cce09fe93e727059a673f2ba24467131a9fb5a4eec76bb1b149c1b3e1ccb268dc583
   languageName: node
   linkType: hard
 
@@ -4332,16 +4312,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express@npm:4.18.2":
-  version: 4.18.2
-  resolution: "express@npm:4.18.2"
+"express@npm:4.19.2":
+  version: 4.19.2
+  resolution: "express@npm:4.19.2"
   dependencies:
     accepts: "npm:~1.3.8"
     array-flatten: "npm:1.1.1"
-    body-parser: "npm:1.20.1"
+    body-parser: "npm:1.20.2"
     content-disposition: "npm:0.5.4"
     content-type: "npm:~1.0.4"
-    cookie: "npm:0.5.0"
+    cookie: "npm:0.6.0"
     cookie-signature: "npm:1.0.6"
     debug: "npm:2.6.9"
     depd: "npm:2.0.0"
@@ -4367,7 +4347,7 @@ __metadata:
     type-is: "npm:~1.6.18"
     utils-merge: "npm:1.0.1"
     vary: "npm:~1.1.2"
-  checksum: 869ae89ed6ff4bed7b373079dc58e5dddcf2915a2669b36037ff78c99d675ae930e5fe052b35c24f56557d28a023bb1cbe3e2f2fb87eaab96a1cedd7e597809d
+  checksum: 3fcd792536f802c059789ef48db3851b87e78fba103423e524144d79af37da7952a2b8d4e1a007f423329c7377d686d9476ac42e7d9ea413b80345d495e30a3a
   languageName: node
   linkType: hard
 
@@ -4667,12 +4647,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fsevents@npm:2.3.2":
+  version: 2.3.2
+  resolution: "fsevents@npm:2.3.2"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 6b5b6f5692372446ff81cf9501c76e3e0459a4852b3b5f1fc72c103198c125a6b8c72f5f166bdd76ffb2fca261e7f6ee5565daf80dca6e571e55bcc589cc1256
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
 "fsevents@npm:^2.3.2, fsevents@npm:~2.3.2":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
     node-gyp: "npm:latest"
   checksum: 4c1ade961ded57cdbfbb5cac5106ec17bc8bccd62e16343c569a0ceeca83b9dfef87550b4dc5cbb89642da412b20c5071f304c8c464b80415446e8e155a038c0
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>":
+  version: 2.3.2
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
+  dependencies:
+    node-gyp: "npm:latest"
   conditions: os=darwin
   languageName: node
   linkType: hard
@@ -8145,23 +8144,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.37.1":
-  version: 1.37.1
-  resolution: "playwright-core@npm:1.37.1"
+"playwright-core@npm:1.44.1":
+  version: 1.44.1
+  resolution: "playwright-core@npm:1.44.1"
   bin:
     playwright-core: cli.js
-  checksum: 9db000892cbe330d5e047e78de11febf53f708bcd8bacaf727eceedb57d67abc7a74e6bb793dabce13b420da8896e6fef840ba1bb9ace2dac3ade3b81f801502
+  checksum: f79f9022bbb760daed371e36c802b27d43dc75e67de4d139d83b47feea51c8b884f3296cce85c3afa71c942290cef1b4369cd9ddf4dda5457a0a81772c73b50a
   languageName: node
   linkType: hard
 
-"playwright@npm:1.37.1":
-  version: 1.37.1
-  resolution: "playwright@npm:1.37.1"
+"playwright@npm:1.44.1":
+  version: 1.44.1
+  resolution: "playwright@npm:1.44.1"
   dependencies:
-    playwright-core: "npm:1.37.1"
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.44.1"
+  dependenciesMeta:
+    fsevents:
+      optional: true
   bin:
     playwright: cli.js
-  checksum: 647cac5e263f0134823e76e21eb7b4c003215fbfb67a16cf3f582c6b37ca032912e0fcf6dea4c5ce763b45a1c38c6feb1f22fe77a07e694d90282a07994c1465
+  checksum: 3207178a78f1c971dddf99c9a08052e462c882092e0d47e3dd8287ced40897a49e387e545a61d31e5d68f7e443d7818660aa12ce43ab662d01d95bcfcfeca2ca
   languageName: node
   linkType: hard
 
@@ -8226,9 +8229,9 @@ __metadata:
   linkType: hard
 
 "process-warning@npm:^2.0.0":
-  version: 2.3.1
-  resolution: "process-warning@npm:2.3.1"
-  checksum: 1c27241fff01886dbb291c1bf4c8bd9f457f09c90d68f1112b1e6a388f1fdc159b50db884fe89a0dcdfbec8b8ca3ffc2caf2bf1a5b7305058179d2b725612425
+  version: 2.3.2
+  resolution: "process-warning@npm:2.3.2"
+  checksum: 64cea6878a60e5d1d3648c1736c127b46d5830092bc189ff65b90abbbf746d69ca91eaeec3284f95b0a58965bb016813da787004b556f764ba439addf2eabdb0
   languageName: node
   linkType: hard
 
@@ -8380,18 +8383,6 @@ __metadata:
   version: 1.2.1
   resolution: "range-parser@npm:1.2.1"
   checksum: ce21ef2a2dd40506893157970dc76e835c78cf56437e26e19189c48d5291e7279314477b06ac38abd6a401b661a6840f7b03bd0b1249da9b691deeaa15872c26
-  languageName: node
-  linkType: hard
-
-"raw-body@npm:2.5.1":
-  version: 2.5.1
-  resolution: "raw-body@npm:2.5.1"
-  dependencies:
-    bytes: "npm:3.1.2"
-    http-errors: "npm:2.0.0"
-    iconv-lite: "npm:0.4.24"
-    unpipe: "npm:1.0.0"
-  checksum: 280bedc12db3490ecd06f740bdcf66093a07535374b51331242382c0e130bb273ebb611b7bc4cba1b4b4e016cc7b1f4b05a6df885a6af39c2bc3b94c02291c84
   languageName: node
   linkType: hard
 
@@ -9486,11 +9477,11 @@ __metadata:
   linkType: hard
 
 "thread-stream@npm:^2.0.0":
-  version: 2.4.1
-  resolution: "thread-stream@npm:2.4.1"
+  version: 2.7.0
+  resolution: "thread-stream@npm:2.7.0"
   dependencies:
     real-require: "npm:^0.2.0"
-  checksum: baac5bf555912f216a2494bf3f66377733a843306cddd233b1c5ad63084307266f61af35d6122e3936c657836d5db4a14da34300cd25930e013943b807a29c9b
+  checksum: 03e743a2ccb2af5fa695d2e4369113336ee9b9f09c4453d50a222cbb4ae3af321bff658e0e5bf8bfbce9d7f5a7bf6262d12a2a365e160f4e76380ec624d32e7b
   languageName: node
   linkType: hard
 
@@ -9901,12 +9892,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:5.27.2":
-  version: 5.27.2
-  resolution: "undici@npm:5.27.2"
+"undici@npm:5.28.4":
+  version: 5.28.4
+  resolution: "undici@npm:5.28.4"
   dependencies:
     "@fastify/busboy": "npm:^2.0.0"
-  checksum: 2bf96b102fb84568fb235bdf6e1e352e5d2bf99566b243cd1b13b41578bf9dd5c7c3d3d82192b20a3fec61fe7a528f9d80cd5b4555ce65405c06c69b023013de
+  checksum: a666a9f5ac4270c659fafc33d78b6b5039a0adbae3e28f934774c85dcc66ea91da907896f12b414bd6f578508b44d5dc206fa636afa0e49a4e1c9e99831ff065
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4324,13 +4324,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"exponential-backoff@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "exponential-backoff@npm:3.1.1"
-  checksum: 2d9bbb6473de7051f96790d5f9a678f32e60ed0aa70741dc7fdc96fec8d631124ec3374ac144387604f05afff9500f31a1d45bd9eee4cdc2e4f9ad2d9b9d5dbd
-  languageName: node
-  linkType: hard
-
 "express@npm:4.19.2":
   version: 4.19.2
   resolution: "express@npm:4.19.2"
@@ -4688,7 +4681,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:2.3.2":
+"fsevents@npm:2.3.2, fsevents@npm:^2.3.2, fsevents@npm:~2.3.2":
   version: 2.3.2
   resolution: "fsevents@npm:2.3.2"
   dependencies:
@@ -4698,26 +4691,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:^2.3.2, fsevents@npm:~2.3.2":
-  version: 2.3.2
-  resolution: "fsevents@npm:2.3.2"
-  dependencies:
-    node-gyp: "npm:latest"
-  checksum: 6b5b6f5692372446ff81cf9501c76e3e0459a4852b3b5f1fc72c103198c125a6b8c72f5f166bdd76ffb2fca261e7f6ee5565daf80dca6e571e55bcc589cc1256
-  conditions: os=darwin
-  languageName: node
-  linkType: hard
-
-"fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>":
-  version: 2.3.2
-  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
-  dependencies:
-    node-gyp: "npm:latest"
-  conditions: os=darwin
-  languageName: node
-  linkType: hard
-
-"fsevents@patch:fsevents@npm%3A^2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>":
+"fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A^2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>":
   version: 2.3.2
   resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
   dependencies:


### PR DESCRIPTION
In this PR:
A little housekeeping and improvements:
- update Playwright to its latest version - will help improve performance and use latest browsers updates
- update Express to its latest minor
- Add a few more flags to the browser's launch to help optimize javascript rendering (search on [this list](https://peter.sh/experiments/chromium-command-line-switches/#disable-backgrounding-occluded-windows) for what they can do) LMK if you prefer in depth explanation on why I think the flags would work.