### PR TITLE
feat: Add tagging to Sentry

### DIFF
--- a/src/helpers/errorReporting.ts
+++ b/src/helpers/errorReporting.ts
@@ -2,6 +2,14 @@ import * as Sentry from '@sentry/node';
 
 import { log } from './logger';
 
+export const RENDERSCRIPT_TASK_URL_TAG = 'renderscript:task:url';
+export const RENDERSCRIPT_TASK_TYPE_TAG = 'renderscript:task:type';
+
+type SentryTag = {
+  key: string;
+  value: string;
+};
+
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   release: process.env.npm_package_version,
@@ -11,7 +19,11 @@ Sentry.init({
   maxBreadcrumbs: 10,
 });
 
-export function report(err: Error, extra: any = {}): void {
+export function report(
+  err: Error,
+  extra: any = {},
+  tags: SentryTag[] = []
+): void {
   if (!process.env.SENTRY_DSN) {
     console.error({ err, extra });
     return;
@@ -19,6 +31,10 @@ export function report(err: Error, extra: any = {}): void {
 
   log.error(err.message, extra);
   Sentry.withScope((scope) => {
+    tags.forEach((tag) => {
+      Sentry.setTag(tag.key, tag.value);
+    });
+
     scope.setExtras(extra);
     Sentry.captureException(err);
   });

--- a/src/lib/TasksManager.ts
+++ b/src/lib/TasksManager.ts
@@ -1,4 +1,8 @@
-import { report } from '../helpers/errorReporting';
+import {
+  RENDERSCRIPT_TASK_TYPE_TAG,
+  RENDERSCRIPT_TASK_URL_TAG,
+  report,
+} from '../helpers/errorReporting';
 import { log as mainLog } from '../helpers/logger';
 import { stats } from '../helpers/stats';
 
@@ -184,7 +188,16 @@ export class TasksManager {
       if (!(err instanceof ErrorIsHandledError)) {
         task.results.error = task.results.error || cleanErrorMessage(err);
         task.results.rawError = err;
-        report(err, { url });
+        report(err, { url }, [
+          {
+            key: RENDERSCRIPT_TASK_URL_TAG,
+            value: url,
+          },
+          {
+            key: RENDERSCRIPT_TASK_TYPE_TAG,
+            value: type,
+          },
+        ]);
       }
       /* eslint-enable no-param-reassign */
     }


### PR DESCRIPTION
Adds tags to some errors related to rendering the page. This is to help track issues within Sentry.