### PR TITLE
fix: ensure the input is a visible element

### DIFF
--- a/src/lib/helpers/getInput.ts
+++ b/src/lib/helpers/getInput.ts
@@ -10,7 +10,7 @@ export async function getInput(
   page: BrowserPage | undefined,
   sel: string
 ): Promise<Locator | { error: HandledError; rawError: Error }> {
-  const textInputLoc = page?.ref?.locator(sel);
+  const textInputLoc = page?.ref?.locator(sel).locator('visible=true');
   const count = textInputLoc ? await textInputLoc.count() : 0;
   if (!textInputLoc || count <= 0) {
     return {


### PR DESCRIPTION
Ensures login inputs we are trying to get is visible on the page.

This fixes the case for inputs that might have custom classes and styles.

Playwright docs: https://playwright.dev/docs/locators#matching-only-visible-elements