### PR TITLE
fix: account for invisible password input fields

### DIFF
--- a/src/lib/helpers/getInput.ts
+++ b/src/lib/helpers/getInput.ts
@@ -4,13 +4,6 @@ import type { BrowserPage } from '../browser/Page';
 import type { HandledError } from '../types';
 
 /**
- * Check if an element is visible.
- */
-function isVisible(element: Element): boolean {
-  return window.getComputedStyle(element).display !== 'none';
-}
-
-/**
  * Get input for selector.
  */
 export async function getInput(
@@ -28,27 +21,35 @@ export async function getInput(
   }
 
   if (count > 1) {
-    // sometimes there are multiple input fields with the same selector
-    // we want to find out if there's a visible one
-    const visibleElements = await textInputLoc!.evaluateAll((elements) => {
-      return elements.filter(isVisible);
-    });
+    try {
+      // sometimes the input is hidden because the page is not fully loaded
+      // wait for the page to be fully loaded
+      await page?.waitForNavigation({
+        waitUntil: 'load',
+        timeout: 10000,
+      });
 
-    if (visibleElements.length !== 1) {
+      // check again but this time only for visible elements
+      const visibleInputLoc = await textInputLoc.locator('visible=true');
+      const visibleCount = visibleInputLoc ? await visibleInputLoc.count() : 0;
+      if (visibleCount === 1) {
+        return visibleInputLoc;
+      }
+
       return {
         error: 'too_many_fields',
         rawError: new Error(
-          `Too many input found for "${sel}", found "${visibleElements.length}"`
+          `Too many input found for "${sel}", found "${count}"`
+        ),
+      };
+    } catch (error) {
+      return {
+        error: 'page_timeout',
+        rawError: new Error(
+          `Page timeout while looking for input "${sel}", found "${count}"`
         ),
       };
     }
-
-    const visibleTextInputLoc = textInputLoc.nth(
-      await textInputLoc.evaluateAll((elements) =>
-        elements.findIndex(isVisible)
-      )
-    );
-    return visibleTextInputLoc;
   }
 
   return textInputLoc;

--- a/src/lib/helpers/getInput.ts
+++ b/src/lib/helpers/getInput.ts
@@ -21,35 +21,26 @@ export async function getInput(
   }
 
   if (count > 1) {
-    try {
-      // sometimes the input is hidden because the page is not fully loaded
-      // wait for the page to be fully loaded
-      await page?.waitForNavigation({
-        waitUntil: 'load',
-        timeout: 10000,
-      });
+    // sometimes another input can be hidden using CSS,
+    // wait for the page to be fully loaded
+    await page?.waitForNavigation({
+      waitUntil: 'load',
+      timeout: 10_000,
+    });
 
-      // check again but this time only for visible elements
-      const visibleInputLoc = await textInputLoc.locator('visible=true');
-      const visibleCount = visibleInputLoc ? await visibleInputLoc.count() : 0;
-      if (visibleCount === 1) {
-        return visibleInputLoc;
-      }
-
-      return {
-        error: 'too_many_fields',
-        rawError: new Error(
-          `Too many input found for "${sel}", found "${count}"`
-        ),
-      };
-    } catch (error) {
-      return {
-        error: 'page_timeout',
-        rawError: new Error(
-          `Page timeout while looking for input "${sel}", found "${count}"`
-        ),
-      };
+    // check again but this time only for visible elements
+    const visibleInputLoc = await textInputLoc.locator('visible=true');
+    const visibleCount = visibleInputLoc ? await visibleInputLoc.count() : 0;
+    if (visibleCount === 1) {
+      return visibleInputLoc;
     }
+
+    return {
+      error: 'too_many_fields',
+      rawError: new Error(
+        `Too many input found for "${sel}", found "${count}"`
+      ),
+    };
   }
 
   return textInputLoc;

--- a/src/lib/helpers/getInput.ts
+++ b/src/lib/helpers/getInput.ts
@@ -4,13 +4,21 @@ import type { BrowserPage } from '../browser/Page';
 import type { HandledError } from '../types';
 
 /**
+ * Check if an element is visible.
+ */
+function isVisible(element: Element): boolean {
+  return window.getComputedStyle(element).display !== 'none';
+}
+
+/**
  * Get input for selector.
  */
 export async function getInput(
   page: BrowserPage | undefined,
   sel: string
 ): Promise<Locator | { error: HandledError; rawError: Error }> {
-  const textInputLoc = page?.ref?.locator(sel).locator('visible=true');
+  const textInputLoc = page?.ref?.locator(sel);
+
   const count = textInputLoc ? await textInputLoc.count() : 0;
   if (!textInputLoc || count <= 0) {
     return {
@@ -20,12 +28,27 @@ export async function getInput(
   }
 
   if (count > 1) {
-    return {
-      error: 'too_many_fields',
-      rawError: new Error(
-        `Too many input found for "${sel}", found "${count}"`
-      ),
-    };
+    // sometimes there are multiple input fields with the same selector
+    // we want to find out if there's a visible one
+    const visibleElements = await textInputLoc!.evaluateAll((elements) => {
+      return elements.filter(isVisible);
+    });
+
+    if (visibleElements.length !== 1) {
+      return {
+        error: 'too_many_fields',
+        rawError: new Error(
+          `Too many input found for "${sel}", found "${visibleElements.length}"`
+        ),
+      };
+    }
+
+    const visibleTextInputLoc = textInputLoc.nth(
+      await textInputLoc.evaluateAll((elements) =>
+        elements.findIndex(isVisible)
+      )
+    );
+    return visibleTextInputLoc;
   }
 
   return textInputLoc;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,7 +15,6 @@ export type HandledError =
   | 'no_cookies'
   | 'page_closed_too_soon'
   | 'page_crashed'
-  | 'page_timeout'
   | 'redirection'
   | 'timedout'
   | 'wrong_redirection';

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,6 +15,7 @@ export type HandledError =
   | 'no_cookies'
   | 'page_closed_too_soon'
   | 'page_crashed'
+  | 'page_timeout'
   | 'redirection'
   | 'timedout'
   | 'wrong_redirection';


### PR DESCRIPTION
Sometimes two inputs appear on a login page, one being invisible (to cater for crawlers or password managers). This PR adds the ability to wait for the page to be fully loaded before selecting the right input.