### PR TITLE
fix(deps): update playwright to 1.45.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "express": "4.19.2",
     "hot-shots": "10.0.0",
     "pino": "8.16.2",
-    "playwright": "1.44.1",
+    "playwright": "1.48.2",
     "undici": "5.28.4",
     "uuid": "9.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,7 +62,7 @@ __metadata:
     nodemon: "npm:3.0.1"
     pino: "npm:8.16.2"
     pino-pretty: "npm:10.2.3"
-    playwright: "npm:1.44.1"
+    playwright: "npm:1.48.2"
     prettier: "npm:3.1.0"
     semantic-release: "npm:22.0.8"
     ts-jest: "npm:29.1.1"
@@ -8216,27 +8216,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.44.1":
-  version: 1.44.1
-  resolution: "playwright-core@npm:1.44.1"
+"playwright-core@npm:1.48.2":
+  version: 1.48.2
+  resolution: "playwright-core@npm:1.48.2"
   bin:
     playwright-core: cli.js
-  checksum: f79f9022bbb760daed371e36c802b27d43dc75e67de4d139d83b47feea51c8b884f3296cce85c3afa71c942290cef1b4369cd9ddf4dda5457a0a81772c73b50a
+  checksum: dd029f797b1afb2240713a032fecc50e1ffc5464a39c075570cf10e929c145da3a8d0951a3f2b279e33b2f09cbeb8ff4330822cb1078452c0c75cc4ce34ca171
   languageName: node
   linkType: hard
 
-"playwright@npm:1.44.1":
-  version: 1.44.1
-  resolution: "playwright@npm:1.44.1"
+"playwright@npm:1.48.2":
+  version: 1.48.2
+  resolution: "playwright@npm:1.48.2"
   dependencies:
     fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.44.1"
+    playwright-core: "npm:1.48.2"
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 3207178a78f1c971dddf99c9a08052e462c882092e0d47e3dd8287ced40897a49e387e545a61d31e5d68f7e443d7818660aa12ce43ab662d01d95bcfcfeca2ca
+  checksum: 331af352504336f419cdf1369f0ef399c6f0e905fdb79a5e97c41f33e74766efd21430ab6ae2de0b237ae765ebfbe701e119a990d8dc01bcdac3bc43c1fa1fbf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR updates Playwright to its latest version to date: v1.45.1

