### PR TITLE
feat: add ability to use latest stable version of chrome

### DIFF
--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -64,6 +64,7 @@ jobs:
           build-args: |
             VERSION=${{ steps.env_var.outputs.RENDERSCRIPT_VERSION }}
             PLAYWRIGHT_VERSION=${{ steps.env_var.outputs.PLAYWRIGHT_VERSION }}
+            USE_LATEST_CHROME=true
 
       - name: Test Image
         run: ./scripts/test_image.sh ${{ env.COMMIT_SHA }}
@@ -85,3 +86,4 @@ jobs:
           build-args: |
             VERSION=${{ steps.env_var.outputs.RENDERSCRIPT_VERSION }}
             PLAYWRIGHT_VERSION=${{ steps.env_var.outputs.PLAYWRIGHT_VERSION }}
+            USE_LATEST_CHROME=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ------------------
 # Build playwright
 # ------------------
-FROM ubuntu:jammy as base
+FROM ubuntu:jammy AS base
 
 # For tzdata
 ARG DEBIAN_FRONTEND=noninteractive
@@ -16,24 +16,38 @@ RUN apt-get update && \
   # Feature-parity with node.js base images.
   apt-get install -y --no-install-recommends git openssh-client && \
   npm install -g yarn && \
-  # clean apt cache
+  # Clean apt cache
   rm -rf /var/lib/apt/lists/* && \
   # Create the pwuser
   adduser pwuser
 
 # === BAKE BROWSERS INTO IMAGE ===
 ARG PLAYWRIGHT_VERSION
-ENV PLAYWRIGHT_VERSION ${PLAYWRIGHT_VERSION}
+ENV PLAYWRIGHT_VERSION=${PLAYWRIGHT_VERSION}
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
 # Browsers will be downloaded in `/ms-playwright`.
 RUN mkdir /ms-playwright \
   && PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=true npm install -g playwright@$PLAYWRIGHT_VERSION \
-  && npx playwright install --with-deps chromium \
   && npx playwright install --with-deps firefox \
   # Clean cache
   && rm -rf /var/lib/apt/lists/* \
   && chmod -R 777 /ms-playwright
+
+# === INSTALL LATEST CHROME ===
+ARG USE_LATEST_CHROME=false
+ENV USE_LATEST_CHROME=${USE_LATEST_CHROME}
+RUN if [ "$USE_LATEST_CHROME" = "true" ]; then \
+  apt-get install -y curl gnupg ca-certificates && \
+  curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg && \
+  echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list && \
+  apt-get update && \
+  apt-get install -y google-chrome-stable && \
+  rm -rf /var/lib/apt/lists/*; \
+  else \
+  npx playwright install --with-deps chromium; \
+  fi
+
 
 
 # ------------------
@@ -49,17 +63,18 @@ RUN jq 'walk(if type == "object" then with_entries(select(.key | test("^jest|pre
 # ------------------
 # New base image
 # ------------------
-FROM base as tmp
+FROM base AS tmp
 
-ENV IN_DOCKER true
+ENV IN_DOCKER=true
 ENV PLAYWRIGHT_BROWSERS_PATH="/ms-playwright"
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD="true"
+ENV USE_LATEST_CHROME="true"
 
 # Setup the app WORKDIR
 WORKDIR /app/tmp
 
 # Copy and install dependencies separately from the app's code
-# To leverage Docker's cache when no dependency has change
+# To leverage Docker's cache when no dependency has changed
 COPY --from=deps /tmp/deps.json ./package.json
 COPY yarn.lock .yarnrc.yml ./
 COPY .yarn .yarn
@@ -68,10 +83,10 @@ COPY .yarn .yarn
 RUN true \
   && yarn install
 
-# This step will invalidates cache
+# This step will invalidate cache
 COPY . ./
 
-# Builds the UI, install chrome and remove dev dependencies
+# Builds the UI, install Chrome, and remove dev dependencies
 RUN true \
   && ls -lah /app/tmp \
   && yarn build \
@@ -81,19 +96,20 @@ RUN true \
 # ------------------
 #  New final image that only contains built code
 # ------------------
-FROM base as final
+FROM base AS final
 
 ARG VERSION
-ENV VERSION ${VERSION:-dev}
+ENV VERSION=${VERSION:-dev}
 
 # Autolink repository https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source=https://github.com/algolia/renderscript
 LABEL org.opencontainers.image.revision=$VERSION
 
-ENV NODE_ENV production
-ENV IN_DOCKER true
+ENV NODE_ENV=production
+ENV IN_DOCKER=true
 ENV PLAYWRIGHT_BROWSERS_PATH="/ms-playwright"
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD="true"
+ENV USE_LATEST_CHROME="true"
 
 # Do not use root to run the app
 USER pwuser

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,6 +12,7 @@ echo ""
 
 # To run locally on your mac m1, you need to change platform to linux/arm64/v8
 # For deploy, it should be linux/amd64
+# USE_LATEST_CHROME will help you download
 docker buildx build \
   --platform linux/amd64 \
   --progress plain \
@@ -20,6 +21,7 @@ docker buildx build \
   -t "algolia/renderscript:${hash}" \
   -t "algolia/renderscript:latest" \
   --build-arg "VERSION=${current}" \
+  --build-arg "USE_LATEST_CHROME=true" \
   --build-arg "PLAYWRIGHT_VERSION=${playwright_version}" \
   --load \
   .

--- a/src/lib/browser/Browser.ts
+++ b/src/lib/browser/Browser.ts
@@ -55,6 +55,13 @@ export class Browser {
     const start = Date.now();
     try {
       const browser = this.#engine === 'firefox' ? firefox : chromium;
+      let executablePath = undefined;
+
+      if (process.env.USE_LATEST_CHROME) {
+        executablePath =
+          this.#engine === 'chromium' ? '/usr/bin/google-chrome' : undefined;
+      }
+
       this.#browser = await browser.launch({
         headless: true,
         env,
@@ -62,6 +69,7 @@ export class Browser {
         handleSIGHUP: false,
         handleSIGTERM: false,
         args: flags,
+        executablePath,
       });
       this.#browser.on('disconnected', () => {
         if (!this.#stopping) {
@@ -82,7 +90,11 @@ export class Browser {
     });
 
     this.#ready = true;
-    log.info('Ready', { id: this.#id, browser: this.#engine });
+    log.info('Ready', {
+      id: this.#id,
+      browser: this.#engine,
+      version: this.#browser?.version(),
+    });
   }
 
   async stop(): Promise<void> {


### PR DESCRIPTION
Update chrome to latest stable version.

This will help skip the playwright's release schedule for chromium and help renderscript use the latest chrome version without waiting for them.

## How
- Downloading chrome in the docker when the build-arg (`USE_LATEST_CHROME`) is set to true
- Force playwright to use that version by setting an `executablePath` to the version provided

## Test
- `yarn docker:build` the vars are already added to the build command
- `docker run -it --rm algolia/renderscript` the browser versions are logged after initialization. It should use latest chrome `131.x.x.x`