### PR TITLE
fix: invalid url catch

### DIFF
--- a/src/lib/helpers/validateURL.ts
+++ b/src/lib/helpers/validateURL.ts
@@ -6,6 +6,14 @@ import { RESTRICTED_IPS } from '../constants';
 
 export async function isURLAllowed(url: string): Promise<boolean> {
   try {
+    // Check for valid URL before validation
+    // eslint-disable-next-line no-new
+    new URL(url);
+  } catch (e) {
+    report(new Error('Invalid url'), { url, err: e });
+    return false;
+  }
+  try {
     await validateURL({
       url,
       ipPrefixes: RESTRICTED_IPS,


### PR DESCRIPTION
sometimes invalid urls are able to pass through, this should stop them and mark them as blocked.

```
TypeError [ERR_INVALID_URL]: Invalid URL
    at new NodeError (node:internal/errors:405:5)
    at new URL (node:internal/url:676:13)
    at Page.<anonymous> (/app/renderscript/dist/lib/browser/Page.js:310:28)
    at Page._callHandler (/app/renderscript/node_modules/playwright-core/lib/client/eventEmitter.js:71:29)
    at Page.emit (/app/renderscript/node_modules/playwright-core/lib/client/eventEmitter.js:66:42)
    at BrowserContext._onRequest (/app/renderscript/node_modules/playwright-core/lib/client/browserContext.js:181:20)
    at Proxy.<anonymous> (/app/renderscript/node_modules/playwright-core/lib/client/browserContext.js:151:16)
    at Proxy._callHandler (/app/renderscript/node_modules/playwright-core/lib/client/eventEmitter.js:71:29)
    at Proxy.emit (/app/renderscript/node_modules/playwright-core/lib/client/eventEmitter.js:62:12)
    at Connection.dispatch (/app/renderscript/node_modules/playwright-core/lib/client/connection.js:202:21)
```